### PR TITLE
Load escape/decode fixes for html and rtf

### DIFF
--- a/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
@@ -5,7 +5,7 @@ using Avalonia.Media.Imaging;
 using HtmlAgilityPack;
 using System.Drawing;
 using System.Globalization;
-using System.Runtime.CompilerServices;
+using System.Net;
 using System.Text.RegularExpressions;
 
 namespace AvRichTextBox;
@@ -294,7 +294,7 @@ internal static partial class HtmlConversions
          switch (inlineNode.Name)
          {
             case "span":
-               EditableRun erun = new() { Text = inlineNode.InnerText };
+               EditableRun erun = new() { Text = WebUtility.HtmlDecode(inlineNode.InnerText) };
 
                foreach (KeyValuePair<string, string> kvp in ParseStyleAttribute(inlineNode.GetAttributeValue("style", "")))
                {

--- a/AvRichTextBox/SaveAndLoadFormats/RtfConversions/ContentToRtf.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/RtfConversions/ContentToRtf.cs
@@ -484,6 +484,8 @@ internal static partial class RtfConversions
 
          if (c is '\\' or '{' or '}')
             sb.Append(@"\" + c); // RTF control characters
+         else if (c == '"')
+            sb.Append(@"\'22"); // Escape double quote
          else if (c > 127) // Non-ASCII (double-byte characters)
             sb.Append(@"\u" + (int)c + "?"); // Unicode escape
          else


### PR DESCRIPTION
**HTML issue:**
When a text with quotation marks like `"test"` is saved as html and loaded again, the displayed text is escaped (`&quot;test&quot;` instead of `"test"`).
The content written to the file is correct:
`<html><head></head><body><p style="text-align:left;background-color:rgba(255,255,255,0);border-color:rgba(0,0,0,1);"><span style="font-family:Times New Roman;font-size:16px;color:rgba(255,255,255,1);background-color:rgba(255,255,255,0);">&quot;test&quot;, Tom &amp; Jerry, &lt;tag&gt;</span></p></body></html>`

Before saving as HTML:  `"test", Tom & Jerry, <tag>`
After loading HTML: `&quot;test&quot;, Tom &amp; Jerry, &lt;tag&gt;`

**RTF issue:**
When saving the same text as rtf, then load again the rtf file, the displayed text is only test without quotation marks:
Before saving as RTF: `"test", Tom & Jerry, <tag>`
After loading RTF: `test, Tom & Jerry, <tag>`

I tested the changes and couldn't reproduce the issue.