### PR TITLE
Add support for loading html underline formatting

### DIFF
--- a/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
@@ -356,6 +356,13 @@ internal static partial class HtmlConversions
                               break;
                         }
                         break;
+
+                     case "text-decoration":
+                        if (kvp.Value.Contains("underline"))
+                           erun.TextDecorations = TextDecorations.Underline;
+                        else if (kvp.Value.Contains("line-through"))
+                           erun.TextDecorations = TextDecorations.Strikethrough;
+                        break;
                   }
                }
 


### PR DESCRIPTION
Currently underline formatting is stored correctly when saving as html, but is ignored when loading. This change adds this functionality.