### PR TITLE
Input improvements (selection / backslash)

### DIFF
--- a/AvRichTextBox/FlowDocument/FlowDocument_SelectionExtend.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_SelectionExtend.cs
@@ -59,6 +59,202 @@ public partial class FlowDocument
       ScrollInDirection?.Invoke(-1);
    }
 
+   internal void ExtendSelectionRightWord()
+   {
+      Selection.BiasForwardEnd = true;
+
+      int targetPos = GetNextWordPosition();
+
+      switch (SelectionExtendMode)
+      {
+         case ExtendMode.ExtendModeNone:
+         case ExtendMode.ExtendModeRight:
+            SelectionExtendMode = ExtendMode.ExtendModeRight;
+            Selection.End = targetPos;
+            break;
+
+         case ExtendMode.ExtendModeLeft:
+            if (targetPos >= Selection.End)
+            {
+               Selection.Start = Selection.End;
+               Selection.End = targetPos;
+               SelectionExtendMode = ExtendMode.ExtendModeRight;
+            }
+            else
+               Selection.Start = targetPos;
+            break;
+      }
+
+      ScrollInDirection?.Invoke(1);
+   }
+
+   internal void ExtendSelectionLeftWord()
+   {
+      Selection.BiasForwardEnd = false;
+
+      int targetPos = GetPreviousWordPosition();
+
+      switch (SelectionExtendMode)
+      {
+         case ExtendMode.ExtendModeNone:
+         case ExtendMode.ExtendModeLeft:
+            SelectionExtendMode = ExtendMode.ExtendModeLeft;
+            Selection.Start = targetPos;
+            break;
+
+         case ExtendMode.ExtendModeRight:
+            if (targetPos <= Selection.Start)
+            {
+               Selection.End = Selection.Start;
+               Selection.Start = targetPos;
+               SelectionExtendMode = ExtendMode.ExtendModeLeft;
+            }
+            else
+               Selection.End = targetPos;
+            break;
+      }
+
+      ScrollInDirection?.Invoke(-1);
+   }
+
+   internal void ExtendSelectionToDocStart()
+   {
+      Selection.BiasForwardStart = true;
+      Selection.BiasForwardEnd = true;
+
+      switch (SelectionExtendMode)
+      {
+         case ExtendMode.ExtendModeNone:
+         case ExtendMode.ExtendModeLeft:
+            SelectionExtendMode = ExtendMode.ExtendModeLeft;
+            Selection.Start = 0;
+            break;
+
+         case ExtendMode.ExtendModeRight:
+            // Was extending right, now selecting all the way to doc start
+            // means we flip direction past the anchor
+            Selection.End = Selection.Start;
+            Selection.Start = 0;
+            SelectionExtendMode = ExtendMode.ExtendModeLeft;
+            break;
+      }
+
+      ScrollInDirection?.Invoke(-1);
+   }
+
+   internal void ExtendSelectionToDocEnd()
+   {
+      Selection.BiasForwardStart = false;
+      Selection.BiasForwardEnd = false;
+
+      List<Paragraph> allPars = AllParagraphs;
+      int docEnd = allPars[^1].StartInDoc + allPars[^1].BlockLength - 1;
+
+      switch (SelectionExtendMode)
+      {
+         case ExtendMode.ExtendModeNone:
+         case ExtendMode.ExtendModeRight:
+            SelectionExtendMode = ExtendMode.ExtendModeRight;
+            Selection.End = docEnd;
+            break;
+
+         case ExtendMode.ExtendModeLeft:
+            // Was extending left, now selecting all the way to doc end
+            // means we flip direction past the anchor
+            Selection.Start = Selection.End;
+            Selection.End = docEnd;
+            SelectionExtendMode = ExtendMode.ExtendModeRight;
+            break;
+      }
+
+      ScrollInDirection?.Invoke(1);
+   }
+
+   /// <summary>
+   /// Computes the position of the next word boundary (rightward) from the current selection end.
+   /// </summary>
+   private int GetNextWordPosition()
+   {
+      // Determine the anchor point based on extend mode
+      int currentPos = (SelectionExtendMode == ExtendMode.ExtendModeLeft) ? Selection.Start : Selection.End;
+
+      Paragraph startP = (SelectionExtendMode == ExtendMode.ExtendModeLeft) ? Selection.StartParagraph : Selection.EndParagraph;
+      int posInBlock = currentPos - startP.StartInDoc;
+
+      if (posInBlock >= startP.TextLength)
+      {
+         // At end of paragraph, move to start of next paragraph
+         int nextPos = startP.StartInDoc + startP.BlockLength;
+         return Math.Min(nextPos, DocEndPoint - 1);
+      }
+
+      string parText = startP.Text;
+
+      // Skip any spaces at the current position
+      int searchFrom = posInBlock;
+      while (searchFrom < parText.Length && (parText[searchFrom] == ' ' || parText[searchFrom] == '\n'))
+         searchFrom++;
+
+      if (searchFrom >= parText.Length)
+         return startP.StartInDoc + startP.TextLength;
+
+      // Find next space from the adjusted position
+      int indexNext = parText.IndexOf(' ', searchFrom);
+      if (indexNext == -1)
+      {
+         // No space found - go to end of paragraph text
+         return startP.StartInDoc + startP.TextLength;
+      }
+      else
+      {
+         // Go to position after the space
+         return startP.StartInDoc + indexNext + 1;
+      }
+   }
+
+   /// <summary>
+   /// Computes the position of the previous word boundary (leftward) from the current selection start.
+   /// </summary>
+   private int GetPreviousWordPosition()
+   {
+      // Determine the anchor point based on extend mode
+      int currentPos = (SelectionExtendMode == ExtendMode.ExtendModeRight) ? Selection.End : Selection.Start;
+
+      if (currentPos <= 0)
+         return 0;
+
+      Paragraph startP = (SelectionExtendMode == ExtendMode.ExtendModeRight) ? Selection.EndParagraph : Selection.StartParagraph;
+      int posInBlock = currentPos - startP.StartInDoc;
+
+      if (posInBlock <= 0)
+      {
+         // At start of paragraph, move to end of previous paragraph
+         return Math.Max(0, startP.StartInDoc - 1);
+      }
+
+      // Skip any spaces immediately to the left of current position
+      int searchFrom = posInBlock - 1;
+      string parText = startP.Text;
+      while (searchFrom > 0 && (parText[searchFrom] == ' ' || parText[searchFrom] == '\n'))
+         searchFrom--;
+
+      if (searchFrom <= 0)
+         return startP.StartInDoc;
+
+      // Find previous space from the adjusted position
+      int indexNext = parText.LastIndexOfAny(" \n".ToCharArray(), searchFrom);
+      if (indexNext == -1)
+      {
+         // No space found - go to start of paragraph
+         return startP.StartInDoc;
+      }
+      else
+      {
+         // Go to position after the space (right of space)
+         return startP.StartInDoc + indexNext + 1;
+      }
+   }
+
    internal void ExtendSelectionDown()
    {
       Selection.BiasForwardEnd = true;

--- a/AvRichTextBox/FlowDocument/FlowDocument_SelectionMove.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_SelectionMove.cs
@@ -348,12 +348,37 @@ public partial class FlowDocument
 
       Selection.BiasForwardStart = true;
       Selection.BiasForwardEnd = true;
-      Selection.Start = Selection.StartParagraph.StartInDoc + Selection.StartParagraph.FirstIndexStartLine;
+
+      int lineStart = Selection.StartParagraph.StartInDoc + Selection.StartParagraph.FirstIndexStartLine;
 
       if (!selExtend)
+      {
+         Selection.Start = lineStart;
          Selection.CollapseToStart();
+         SelectionExtendMode = ExtendMode.ExtendModeNone;
+      }
       else
-         SelectionExtendMode = ExtendMode.ExtendModeLeft;
+      {
+         switch (SelectionExtendMode)
+         {
+            case ExtendMode.ExtendModeNone:
+            case ExtendMode.ExtendModeLeft:
+               Selection.Start = lineStart;
+               SelectionExtendMode = ExtendMode.ExtendModeLeft;
+               break;
+
+            case ExtendMode.ExtendModeRight:
+               // Was extending right; now SHIFT+Home should flip direction.
+               // The anchor is Selection.Start, the active end was Selection.End.
+               // We need to move the active end to line start, which is before the anchor,
+               // so flip: new End = old Start (anchor), new Start = lineStart.
+               int anchor = Selection.Start;
+               Selection.End = anchor;
+               Selection.Start = lineStart;
+               SelectionExtendMode = ExtendMode.ExtendModeLeft;
+               break;
+         }
+      }
 
       ScrollInDirection?.Invoke(-1);
 
@@ -366,6 +391,14 @@ public partial class FlowDocument
       Selection.BiasForwardEnd = false;
 
       if (Selection.StartParagraph.TextLength == 0) return;
+
+      // When flipping from ExtendModeLeft, the anchor is Selection.End.
+      // We need to reset Start to the anchor before computing the new End.
+      if (selExtend && SelectionExtendMode == ExtendMode.ExtendModeLeft)
+      {
+         int anchor = Selection.End;
+         Selection.Start = anchor;
+      }
 
       Paragraph thisEndPar = Selection.EndParagraph;
 
@@ -382,7 +415,10 @@ public partial class FlowDocument
       }
 
       if (!selExtend)
+      {
          Selection.CollapseToEnd();
+         SelectionExtendMode = ExtendMode.ExtendModeNone;
+      }
       else
          SelectionExtendMode = ExtendMode.ExtendModeRight;
 

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -33,6 +33,7 @@ public partial class RichTextBox
                break;
 
             case Key.X:
+               if (IsReadOnly) return;
                CopyToClipboard();
                PerformDelete(false);
                break;

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -33,9 +33,7 @@ public partial class RichTextBox
                break;
 
             case Key.X:
-               if (IsReadOnly) return;
-               CopyToClipboard();
-               PerformDelete(false);
+               CutToClipboard();
                break;
 
             case Key.V:

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -10,7 +10,7 @@ public partial class RichTextBox
    private void RichTextBox_KeyDown(object? sender, KeyEventArgs e)
    {
 
-      if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
+      if (e.KeyModifiers.HasFlag(KeyModifiers.Control) && !e.KeyModifiers.HasFlag(KeyModifiers.Alt))
       {
          e.Handled = true;
 

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -32,6 +32,11 @@ public partial class RichTextBox
                CopyToClipboard();
                break;
 
+            case Key.X:
+               CopyToClipboard();
+               PerformDelete(false);
+               break;
+
             case Key.V:
                PasteFromClipboard();
                break;

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -36,13 +36,21 @@ public partial class RichTextBox
                PasteFromClipboard();
                break;
 
-            case Key.Home: // Ctrl-Home 
-               FlowDoc.MoveToDocStart();
-               FlowDocSV.ScrollToHome();
+            case Key.Home: // Ctrl-Home / Ctrl-Shift-Home
+               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+                  FlowDoc.ExtendSelectionToDocStart();
+               else
+               {
+                  FlowDoc.MoveToDocStart();
+                  FlowDocSV.ScrollToHome();
+               }
                break;
 
-            case Key.End: // Ctrl-End 
-               FlowDoc.MoveToDocEnd();
+            case Key.End: // Ctrl-End / Ctrl-Shift-End
+               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+                  FlowDoc.ExtendSelectionToDocEnd();
+               else
+                  FlowDoc.MoveToDocEnd();
                break;
 
             case Key.Z:
@@ -64,11 +72,17 @@ public partial class RichTextBox
                break;
 
             case Key.Right:
-               FlowDoc.MoveRightWord();
+               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+                  FlowDoc.ExtendSelectionRightWord();
+               else
+                  FlowDoc.MoveRightWord();
                break;
 
             case Key.Left:
-               FlowDoc.MoveLeftWord();
+               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+                  FlowDoc.ExtendSelectionLeftWord();
+               else
+                  FlowDoc.MoveLeftWord();
                break;
          }
       }

--- a/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
@@ -31,17 +31,17 @@ public partial class RichTextBox
 
    }
 
-   
+
    private void CopyToClipboard()
-   {      
+   {
       if (DisableUserCopy) return;
-     
+
       var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
       if (clipboard == null) return;
       //create rtf string
       List<IEditable> newInlines = FlowDoc.GetRangeInlines(FlowDoc.Selection);
       string rtfString = RtfConversions.GetRtfFromInlines(newInlines);
-      
+
       var dataTransfer = new DataTransfer();
 
       // Rtf format
@@ -57,8 +57,8 @@ public partial class RichTextBox
    }
 
    readonly static DataFormat<byte[]> richTextFormat = DataFormat.CreateBytesPlatformFormat("Rich Text Format");
-   
-  
+
+
    private async void PasteFromClipboard()
    {
       if (IsReadOnly) return;
@@ -71,7 +71,7 @@ public partial class RichTextBox
       int originalSelectionStart = FlowDoc.Selection.Start;
       int originalSelectionEnd = FlowDoc.Selection.End;
       TextRange insertRange = FlowDoc.Selection;
-      List<Paragraph> originalRangeParagraphs = FlowDoc.GetOverlappingParagraphsInRange(insertRange).ConvertAll(op=>op.FullClone());
+      List<Paragraph> originalRangeParagraphs = FlowDoc.GetOverlappingParagraphsInRange(insertRange).ConvertAll(op => op.FullClone());
       int deleteRangeLength = insertRange.Length;
       Paragraph startPar = insertRange.StartParagraph;
       int insertParIndex = FlowDoc.Blocks.IndexOf(startPar);
@@ -91,7 +91,7 @@ public partial class RichTextBox
          contentPasted = true;
       }
 
-      else if (await clipboard.TryGetBitmapAsync() is Bitmap pasteBitmap) 
+      else if (await clipboard.TryGetBitmapAsync() is Bitmap pasteBitmap)
       {
          Image pasteImage = new() { Source = pasteBitmap };
          EditableInlineUIContainer newEIUC = new(pasteImage);
@@ -141,6 +141,13 @@ public partial class RichTextBox
 
 
    }
-    
-  
+
+   private void CutToClipboard()
+   {
+      if (IsReadOnly) return;
+      CopyToClipboard();
+      PerformDelete(false);
+   }
+
+
 }


### PR DESCRIPTION
Changes:
 - Enables text selection using CTRL+SHIFT+Left/Right
 - Enables text selection using CTRL+SHIFT+Pos1/End
 - Fixes Text selection inside the same line with SHIFT+Left/Right (selection was previously expanded)
 - Entering Backslash is now possible
 - Adds CTRL+X shortcut to cut selected text
 
Note that most of thoses changes were done with the help of Claude Opus 4.6. It tested all changes and it works as expected as far as I can tell.