### PR TITLE
fix paste with existing selection

### DIFF
--- a/AvRichTextBox/FlowDocument/FlowDocument_Insert.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Insert.cs
@@ -12,10 +12,7 @@ public partial class FlowDocument
    internal int InsertRTF(byte[] rtfbytes, Paragraph startPar, TextRange insertRange, int insertParIndex, List<int> addedBlockIds)
    {
       (int leftId, int rightId) edgeIds = DeleteRange(insertRange, false, false);
-
-      IEditable leftInline = startPar.Inlines.FirstOrDefault(il => il.Id == edgeIds.leftId)!;
-      int insertIdx = (insertRange.Start == startPar.StartInDoc) ? 0 : startPar.Inlines.IndexOf(leftInline) + 1;
-      //Debug.WriteLine("insertidx = " + insertIdx + "\nleftinline = " + startPar.Inlines.FirstOrDefault(il => il.Id == edgeIds.leftId)!.InlineText);
+      int insertIdx = GetInsertIndexAfterDelete(startPar, edgeIds.leftId, insertRange);
 
       List<IEditable> rightSplitRuns = startPar.Inlines.ToList()[insertIdx..];
 
@@ -23,6 +20,23 @@ public partial class FlowDocument
 
       return ProcessInsertBlocks(rtfBlocks, startPar, insertIdx, insertParIndex, addedBlockIds, rightSplitRuns);
 
+   }
+
+
+   private int GetInsertIndexAfterDelete(Paragraph startPar, int leftId, TextRange insertRange)
+   {
+      if (insertRange.Start == startPar.StartInDoc)
+         return 0;
+
+      IEditable? leftInline = startPar.Inlines.FirstOrDefault(il => il.Id == leftId);
+      if (leftInline != null)
+         return startPar.Inlines.IndexOf(leftInline) + 1;
+
+      // The inline referenced by leftId was fully deleted.
+      // Calculate insert index from the character position instead.
+      int posInPar = insertRange.Start - startPar.StartInDoc;
+      IEditable? precedingInline = startPar.Inlines.LastOrDefault(il => il.TextPositionOfInlineInParagraph + il.InlineLength <= posInPar);
+      return precedingInline != null ? startPar.Inlines.IndexOf(precedingInline) + 1 : 0;
    }
 
 
@@ -64,7 +78,8 @@ public partial class FlowDocument
    internal int InsertXaml(byte[] xamlbytes, Paragraph startPar, Paragraph endPar, TextRange insertRange, int insertParIndex, List<int> addedBlockIds)
    {
       (int leftId, int rightId) edgeIds = DeleteRange(insertRange, false, false);
-      int insertIdx = startPar.Inlines.IndexOf(startPar.Inlines.FirstOrDefault(il => il.Id == edgeIds.leftId)!) + 1;
+      int insertIdx = GetInsertIndexAfterDelete(startPar, edgeIds.leftId, insertRange);
+
       List<IEditable> rightSplitRuns = endPar.Inlines.ToList()[insertIdx..];
 
       string xamlString = Encoding.ASCII.GetString(xamlbytes);

--- a/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
@@ -2,6 +2,7 @@
 using Avalonia.Input.Platform;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using DynamicData;
 using System.Text;
 using static AvRichTextBox.FlowDocument;
@@ -118,26 +119,31 @@ public partial class RichTextBox
 
       FlowDoc.disableRunTextUndo = false;
 
-      //Update based on pasted content
-      if (contentPasted)
-      {
-         if (addUndo)
-            FlowDoc.Undos.Add(new PasteUndo(originalRangeParagraphs, insertParIndex, FlowDoc, originalSelectionStart, deleteRangeLength - pastedTextLength, firstParEmpty, addedBlockIds, firstParWasDeleted));
+       //Update based on pasted content
+       if (contentPasted)
+       {
+          if (addUndo)
+             FlowDoc.Undos.Add(new PasteUndo(originalRangeParagraphs, insertParIndex, FlowDoc, originalSelectionStart, deleteRangeLength - pastedTextLength, firstParEmpty, addedBlockIds, firstParWasDeleted));
 
-         this.DocIC.UpdateLayout();
-         FlowDoc.UpdateBlockAndInlineStarts(insertParIndex);
-         FlowDoc.UpdateSelection();
-         FlowDoc.Select(originalSelectionStart + pastedTextLength, 0);
-         FlowDoc.Selection.BiasForwardStart = false;
-         FlowDoc.Selection.BiasForwardEnd = false;
-         FlowDoc.SelectionExtendMode = ExtendMode.ExtendModeNone;
-         FlowDoc.ScrollFlowDocInDirection(1);
+          this.DocIC.UpdateLayout();
+          FlowDoc.UpdateBlockAndInlineStarts(insertParIndex);
+          FlowDoc.UpdateSelection();
+          FlowDoc.SelectionExtendMode = ExtendMode.ExtendModeNone;
 
-         CreateClient();
+          CreateClient();
 
-         _ = FlowDoc.AsyncUpdateCaret(FlowDoc.Selection);
+          // Defer caret positioning to after layout has completed for newly inserted paragraphs.
+          // Without this, the caret can appear at the wrong position.
+          Dispatcher.UIThread.Post(() =>
+          {
+             FlowDoc.Select(originalSelectionStart + pastedTextLength, 0);
+             FlowDoc.Selection.BiasForwardStart = false;
+             FlowDoc.Selection.BiasForwardEnd = false;
+             FlowDoc.ScrollFlowDocInDirection(1);
+             _ = FlowDoc.AsyncUpdateCaret(FlowDoc.Selection);
+          });
 
-      }
+       }
 
 
    }


### PR DESCRIPTION
Currently the insert position of pasted text is not as expected if there is text selected while pasting the new text. With the change in the PR I couldn't reproduce the issue.

There is a related issue that is also fixed that I encountered while working on the issue of the PR: 
When selecting everything, copying it to the clipboard and then pasting it again, the caret position is not always correct (only happens when there is more than one line). There was an issue with timing (caret positioning has to be defered to after layout has completed).