### PR TITLE
Improve html newline handling

### DIFF
--- a/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/ContentToHtml.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/ContentToHtml.cs
@@ -17,7 +17,7 @@ internal static partial class HtmlConversions
    {
 
       HtmlDocument hdoc = new();
-      
+
       HtmlNode html = hdoc.CreateElement("html");
       HtmlNode head = hdoc.CreateElement("head");
       HtmlNode body = hdoc.CreateElement("body");
@@ -51,14 +51,14 @@ internal static partial class HtmlConversions
                break;
          }
       }
-      
+
       return hdoc;
-        
+
    }
 
    private static HtmlNode GetTableNode(Table t, HtmlDocument hdoc)
    {
-    
+
       int noCols = t.ColDefs.Count;
       double colWidthPerc = Math.Round(100D / noCols);
 
@@ -77,7 +77,7 @@ internal static partial class HtmlConversions
       string tabBorderCol = ColorToCss(t.BorderBrush.Color);
 
       HtmlNode tableNode = hdoc.CreateElement("table");
-      string tableStyleString = 
+      string tableStyleString =
          "border-spacing: 0;" +
          "border-collapse: collapse;" +
          $"border: {tabBorderThickness}px solid {tabBorderCol};" +
@@ -109,7 +109,7 @@ internal static partial class HtmlConversions
             {
                HtmlNode cellNode = hdoc.CreateElement("td");
 
-               string valignString = thisCell.CellVerticalAlignment switch { VerticalAlignment.Top => "top", VerticalAlignment.Center => "center" , VerticalAlignment.Bottom => "bottom", _=> "center"};
+               string valignString = thisCell.CellVerticalAlignment switch { VerticalAlignment.Top => "top", VerticalAlignment.Center => "center", VerticalAlignment.Bottom => "bottom", _ => "center" };
 
                string cellStyleString =
                   $"border-width: {thisCell.BorderThickness.Top}px {thisCell.BorderThickness.Right}px {thisCell.BorderThickness.Bottom}px {thisCell.BorderThickness.Left}px;" +
@@ -136,55 +136,72 @@ internal static partial class HtmlConversions
       }
 
       return tableNode;
-      
+
 
    }
 
- 
+
    private static HtmlNode GetParagraphNode(Paragraph p, HtmlDocument hdoc)
    {
       HtmlNode parnode = hdoc.CreateElement("p");
 
+      bool hasContent = false;
+
       foreach (IEditable ied in p.Inlines)
       {
-         HtmlNode spanNode = hdoc.CreateElement("span");
-
          switch (ied)
          {
             case EditableRun erun:
-               spanNode.InnerHtml = WebUtility.HtmlEncode(erun.Text ?? "");
-               spanNode.SetAttributeValue("style", GetInlineStyle(erun));
-               break;
+               {
+                  if (!string.IsNullOrEmpty(erun.Text))
+                  {
+                     var spanNode = hdoc.CreateElement("span");
+                     spanNode.InnerHtml = WebUtility.HtmlEncode(erun.Text ?? "");
+                     spanNode.SetAttributeValue("style", GetInlineStyle(erun));
+                     parnode.AppendChild(spanNode);
+                     hasContent = true;
+                  }
+                  break;
+               }
 
-            case EditableLineBreak elbreak:
-               spanNode = hdoc.CreateElement("br");
-               break;
+            case EditableLineBreak:
+               {
+                  var brNode = hdoc.CreateElement("br");
+                  parnode.AppendChild(brNode);
+                  hasContent = true;
+                  break;
+               }
 
             case EditableInlineUIContainer eUIC:
-
-               if (eUIC.Child is Image img && img.Source is Bitmap bmp)
                {
-                  using var memStream = new MemoryStream();
-                  bmp.Save(memStream);
-                  var base64 = Convert.ToBase64String(memStream.ToArray());
+                  if (eUIC.Child is Image img && img.Source is Bitmap bmp)
+                  {
+                     using var memStream = new MemoryStream();
+                     bmp.Save(memStream);
+                     var base64 = Convert.ToBase64String(memStream.ToArray());
 
-                  var imgNode = hdoc.CreateElement("img");
-                  imgNode.SetAttributeValue("src", $"data:image/png;base64,{base64}");
-                  imgNode.SetAttributeValue("width", img.Width.ToString());
-                  imgNode.SetAttributeValue("height", img.Height.ToString());
+                     var imgNode = hdoc.CreateElement("img");
+                     imgNode.SetAttributeValue("src", $"data:image/png;base64,{base64}");
+                     imgNode.SetAttributeValue("width", img.Width.ToString());
+                     imgNode.SetAttributeValue("height", img.Height.ToString());
 
-                  parnode.AppendChild(imgNode);
+                     parnode.AppendChild(imgNode);
+                     hasContent = true;
+                  }
+                  break;
                }
-               break;
          }
-         parnode.AppendChild(spanNode);
+      }
+
+      if (!hasContent)
+      {
+         parnode.AppendChild(hdoc.CreateElement("br"));
       }
 
       parnode.SetAttributeValue("style", GetParStyle(p));
-
       return parnode;
-
    }
+
 
    private static string GetParStyle(Paragraph p)
    {
@@ -245,7 +262,7 @@ internal static partial class HtmlConversions
 
       string? foregroundColor = ToCssColor(run.Foreground, Brushes.Black);
       if (foregroundColor != null)
-         sb.Append($"color:{foregroundColor};"); 
+         sb.Append($"color:{foregroundColor};");
 
       string? backgroundColor = ToCssColor(run.Background, Brushes.Transparent);
       if (backgroundColor != null)

--- a/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
@@ -63,7 +63,7 @@ internal static partial class HtmlConversions
    private static Table GetTableFromNode(HtmlNode tableNode, FlowDocument fdoc)
    {
       Table newTable = new(fdoc);
-      
+
       int noCols = 0;
       var colNodes = tableNode.SelectNodes("./colgroup/col");
       if (colNodes != null && colNodes.Count > 0)
@@ -115,7 +115,7 @@ internal static partial class HtmlConversions
          int rowSpan = 1;
 
          foreach (var td in cellNodes)
-         {          
+         {
             while (colNo < noCols && rowNo < nextAvailableRows[colNo])
                colNo++;
 
@@ -127,7 +127,7 @@ internal static partial class HtmlConversions
                   rowSpan = Math.Max(1, Int32.Parse(att.Value));
             }
 
-        
+
             var newCell = new Cell(newTable)
             {
                RowNo = rowNo,
@@ -140,10 +140,10 @@ internal static partial class HtmlConversions
 
 
             Dictionary<string, string> parsedCellStyles = ParseStyleAttribute(td.GetAttributeValue("style", ""));
-            
+
             ISolidColorBrush cellBorderBrush = Brushes.Black;
             Thickness cellBorderThickness = new(1);
-            
+
             GetBordersFromCssStyle(parsedCellStyles, ref cellBorderBrush, ref cellBorderThickness);
             newCell.BorderBrush = cellBorderBrush;
             newCell.BorderThickness = cellBorderThickness;
@@ -152,8 +152,8 @@ internal static partial class HtmlConversions
             if (parsedCellStyles.TryGetValue("background-color", out var backgroundColorString))
                if (ParseCssColor(backgroundColorString) is ISolidColorBrush bgc)
                   newCell.CellBackground = bgc;
-            
-            
+
+
             if (parsedCellStyles.TryGetValue("padding", out var paddingString))
             {
                if (paddingString.Contains(' '))
@@ -168,8 +168,8 @@ internal static partial class HtmlConversions
                      newCell.Padding = new Thickness(padding);
                }
             }
-                           
-           
+
+
             if (parsedCellStyles.TryGetValue("vertical-align", out var cellVerticalAlign))
                switch (cellVerticalAlign)
                {
@@ -177,7 +177,7 @@ internal static partial class HtmlConversions
                   case "center": newCell.CellVerticalAlignment = VerticalAlignment.Center; break;
                   case "bottom": newCell.CellVerticalAlignment = VerticalAlignment.Bottom; break;
                }
-            
+
 
             HtmlNode? contentNode = td.ChildNodes.FirstOrDefault(n => n.NodeType == HtmlNodeType.Element);
 
@@ -202,9 +202,9 @@ internal static partial class HtmlConversions
 
       return newTable;
 
-   }   
+   }
 
-   private static void GetBordersFromCssStyle(Dictionary<string, string> parsedStyles, ref ISolidColorBrush cellBorderBrush, ref Thickness  cellBorderThickness)
+   private static void GetBordersFromCssStyle(Dictionary<string, string> parsedStyles, ref ISolidColorBrush cellBorderBrush, ref Thickness cellBorderThickness)
    {
       foreach (KeyValuePair<string, string> kvp in parsedStyles)
       {
@@ -245,7 +245,7 @@ internal static partial class HtmlConversions
       if (styles.TryGetValue("margin", out var marginVal))
       {
          var parts = marginVal.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim().ToLowerInvariant()).ToArray();
-              
+
          if (parts.Length == 1)
          {
             ml ??= parts[0];
@@ -277,7 +277,7 @@ internal static partial class HtmlConversions
 
       if (leftAuto && rightAuto)
          tableHorizAlignment = HorizontalAlignment.Center;
-       else if (leftAuto && !rightAuto)
+      else if (leftAuto && !rightAuto)
          tableHorizAlignment = HorizontalAlignment.Right;
       else
          tableHorizAlignment = HorizontalAlignment.Left;
@@ -517,14 +517,34 @@ internal static partial class HtmlConversions
       }
    }
 
+   /// <summary>
+   /// special case: <p><br></p> => empty paragraph
+   /// </summary>
+   /// <param name="paragraphNode"></param>
+   /// <returns></returns>
+   private static bool IsHtmlEmptyParagraph(HtmlNode paragraphNode)
+   {
+      var elementChildren = paragraphNode.ChildNodes
+          .Where(n => n.NodeType == HtmlNodeType.Element)
+          .ToList();
+
+      var textContent = WebUtility.HtmlDecode(paragraphNode.InnerText);
+
+      return elementChildren.Count == 1
+          && elementChildren[0].Name.Equals("br", StringComparison.OrdinalIgnoreCase)
+          && string.IsNullOrWhiteSpace(textContent);
+   }
+
 
    private static Paragraph GetParagraphFromNode(HtmlNode childNode, FlowDocument fdoc)
    {
-      
       Paragraph par = new(fdoc);
 
-      InlineFormatting defaultFormatting = new();
-      AddInlinesFromNode(childNode, par, defaultFormatting);
+      if (!IsHtmlEmptyParagraph(childNode))
+      {
+         InlineFormatting defaultFormatting = new();
+         AddInlinesFromNode(childNode, par, defaultFormatting);
+      }
 
       foreach (KeyValuePair<string, string> kvp in ParseStyleAttribute(childNode.GetAttributeValue("style", "")))
       {
@@ -535,7 +555,7 @@ internal static partial class HtmlConversions
                if (par.Inlines.Count > 0)
                {
                   double lineHeight = Double.TryParse(kvp.Value.Replace("px", ""), out var px) ? px : 0;
-                  double maxInlineHeight = par.Inlines.Max(ilh => ilh.InlineHeight);
+                  //double maxInlineHeight = par.Inlines.Max(ilh => ilh.InlineHeight);
                   //par.LineHeight = LineHeightToLineSpacing(lineHeight, maxInlineHeight);
                   par.LineHeight = lineHeight;
                }
@@ -567,7 +587,7 @@ internal static partial class HtmlConversions
                   if (int.Parse(marginString.Replace("px", "")) is int padding)
                      par.Margin = new Thickness(padding);
                }
-               
+
                break;
 
             case "background-color":
@@ -591,17 +611,17 @@ internal static partial class HtmlConversions
 
    }
 
-   private static Thickness GetBorderThickness (string val)
+   private static Thickness GetBorderThickness(string val)
    {
-      Thickness returnThickness = new (1);
-      
+      Thickness returnThickness = new(1);
+
       var bwidths = val.Split(' ').Select(val => int.TryParse(val.Replace("px", ""), out var px) ? px : 0).ToList();
       if (bwidths.Count == 4)
          returnThickness = new Thickness(bwidths[3], bwidths[0], bwidths[1], bwidths[2]);
 
       return returnThickness;
 
-      
+
    }
 
    private static Dictionary<string, string> ParseStyleAttribute(string? style)


### PR DESCRIPTION
(description from https://github.com/cuikp/AvRichTextBox/issues/33#issuecomment-4358608710) 
I tested newline handling for rtf/xaml/html and for html I found the issue that the control handles` <p></p>` as new line, wheras LibreOffice Writer or Browsers don't. When saving as html with LibreOffice Writer empty newlines are saved as `<p><br/></p>`
The commit changes loading / saving HTML, so that the resulting html also looks the same in Browsers or when loading with Writer.

To reproduce the issue:
Create this text in the control, save it as html, and open it in a browser:

> Line 1
> 
> Line 2

-> Collapsed line break (or in Libreoffice Writer: empty line missing)

Then create the same txt in for example LibreOffice Writer, and save as HTML. Load the html-file in the control. -> additional linebreak