### PR TITLE
Paste as plain text functionality

### DIFF
--- a/AvRichTextBox/FlowDocument/FlowDocument_EditingFunctions.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_EditingFunctions.cs
@@ -8,52 +8,54 @@ namespace AvRichTextBox;
 
 public partial class FlowDocument
 {  
-   internal void SetRangeToText(TextRange tRange, string newText)
-   {  //The delete range and SetRangeToText should constitute one Undo operation
+    internal void SetRangeToText(TextRange tRange, string newText, bool copyFormatting = true)
+    {  //The delete range and SetRangeToText should constitute one Undo operation
 
-      Paragraph startPar = tRange.StartParagraph;
-      int rangeStart = tRange.Start;
-      int rangeEnd = tRange.End;
-      int deleteRangeLength = tRange.Length;
-      int parIndex = Blocks.IndexOf(startPar);
-      bool firstParEmpty = startPar.Inlines[0] is EditableRun erun && erun.Text == "";
-      bool firstParWasDeleted = startPar.StartInDoc == rangeStart && startPar.EndInDoc <= rangeEnd && !firstParEmpty; 
+       Paragraph startPar = tRange.StartParagraph;
+       int rangeStart = tRange.Start;
+       int rangeEnd = tRange.End;
+       int deleteRangeLength = tRange.Length;
+       int parIndex = Blocks.IndexOf(startPar);
+       bool firstParEmpty = startPar.Inlines[0] is EditableRun erun && erun.Text == "";
+       bool firstParWasDeleted = startPar.StartInDoc == rangeStart && startPar.EndInDoc <= rangeEnd && !firstParEmpty;
 
-      //Delete any selected text first
-      if (tRange.Length > 0)
-      {
-         DeleteRange(tRange, false, false);  // no undo, handled by PasteUndo
-         tRange.CollapseToStart();
-         SelectionExtendMode = ExtendMode.ExtendModeNone;
-      }
+       //Delete any selected text first
+       if (tRange.Length > 0)
+       {
+          DeleteRange(tRange, false, false);  // no undo, handled by PasteUndo
+          tRange.CollapseToStart();
+          SelectionExtendMode = ExtendMode.ExtendModeNone;
+       }
 
-      //Debug.WriteLine("first par deleted: " + firstParWasDeleted);
+       //Debug.WriteLine("first par deleted: " + firstParWasDeleted);
 
       if (tRange.StartInline is not IEditable startInline) return;
 
-      List<IEditable> splitInlines = SplitRunAtPos(tRange.Start, startInline, GetCharPosInInline(startInline, tRange.Start));
+       List<IEditable> splitInlines = SplitRunAtPos(tRange.Start, startInline, GetCharPosInInline(startInline, tRange.Start));
 
-      int startInlineIndex = startPar.Inlines.IndexOf(splitInlines[0]) + 1;
+       int startInlineIndex = startPar.Inlines.IndexOf(splitInlines[0]) + 1;
 
-      if (splitInlines[0] is EditableRun sRun)
-      {
-         EditableRun newEditableRun = new(newText)
-         {
-            FontFamily = sRun.FontFamily,
-            FontWeight = sRun.FontWeight,
-            FontStyle = sRun.FontStyle,
-            FontSize = sRun.FontSize,
-            TextDecorations = sRun.TextDecorations,
-            Background = sRun.Background,
-            BaselineAlignment = sRun.BaselineAlignment,
-            Foreground = sRun.Foreground
-         };
+       if (splitInlines[0] is EditableRun sRun)
+       {
+          EditableRun newEditableRun = new(newText);
 
-         startPar.Inlines.Insert(startInlineIndex, newEditableRun);
+          if (copyFormatting)
+          {
+             newEditableRun.FontFamily = sRun.FontFamily;
+             newEditableRun.FontWeight = sRun.FontWeight;
+             newEditableRun.FontStyle = sRun.FontStyle;
+             newEditableRun.FontSize = sRun.FontSize;
+             newEditableRun.TextDecorations = sRun.TextDecorations;
+             newEditableRun.Background = sRun.Background;
+             newEditableRun.BaselineAlignment = sRun.BaselineAlignment;
+             newEditableRun.Foreground = sRun.Foreground;
+          }
 
-         if (splitInlines[0].InlineText == "")
-            startPar.Inlines.Remove(splitInlines[0]);
-      }
+          startPar.Inlines.Insert(startInlineIndex, newEditableRun);
+
+          if (splitInlines[0].InlineText == "")
+             startPar.Inlines.Remove(splitInlines[0]);
+       }
 
       startPar.CallRequestInvalidateVisual();
       startPar.CallRequestTextLayoutInfoStart();

--- a/AvRichTextBox/RichTextBox/RichTextBox.axaml
+++ b/AvRichTextBox/RichTextBox/RichTextBox.axaml
@@ -77,6 +77,7 @@
 					<ContextMenu x:Name="DocContextMenu" Opening="DocContextMenu_Opening">
 						<MenuItem Header="Copy" Click="CopySelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
 						<MenuItem Header="Paste" Click="PasteSelectionMenuItem_Click" />
+						<MenuItem Header="Paste without formatting" Click="PasteSelectionAsPlainTextMenuItem_Click" />
 						<MenuItem Header="Cut" Click="CutSelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
 						<MenuItem Header="Delete" Click="DeleteSelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
 						<Separator/>

--- a/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
@@ -319,6 +319,12 @@ public partial class RichTextBox : UserControl
       if (IsReadOnly) return;
       PasteFromClipboard();
    }
+   
+   private void PasteSelectionAsPlainTextMenuItem_Click(object? sender, RoutedEventArgs e)
+   {
+      if (IsReadOnly) return;
+      PasteFromClipboardAsPlainText();
+   }
 
    private void CutSelectionMenuItem_Click(object? sender, RoutedEventArgs e)
    {

--- a/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
@@ -323,7 +323,7 @@ public partial class RichTextBox : UserControl
    private void PasteSelectionAsPlainTextMenuItem_Click(object? sender, RoutedEventArgs e)
    {
       if (IsReadOnly) return;
-      PasteFromClipboardAsPlainText();
+      PasteFromClipboard(plainTextOnly: true);
    }
 
    private void CutSelectionMenuItem_Click(object? sender, RoutedEventArgs e)

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -23,7 +23,7 @@ public partial class RichTextBox
       { new(Key.C, Ctrl: true), () => CopyToClipboard() },
       { new(Key.X, Ctrl: true), () => CutToClipboard() },
       { new(Key.V, Ctrl: true), () => PasteFromClipboard() },
-      { new(Key.V, Ctrl: true, Shift: true), () => PasteFromClipboardAsPlainText() },
+      { new(Key.V, Ctrl: true, Shift: true), () => PasteFromClipboard(plainTextOnly: true) },
 
       { new(Key.Z, Ctrl: true), () =>
          {

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -1,215 +1,296 @@
 using Avalonia.Input;
-using System.Diagnostics;
 
 namespace AvRichTextBox;
 
 public partial class RichTextBox
-{  
+{
+   private readonly record struct KeyCombo(
+      Key Key,
+      bool Ctrl = false,
+      bool Shift = false,
+      bool Alt = false
+   );
+
+   private Dictionary<KeyCombo, Action>? _keyActions;
+
+   private Dictionary<KeyCombo, Action> KeyActions => _keyActions ??= new()
+   {
+      // Ctrl shortcuts
+      { new(Key.B, Ctrl: true), () => ToggleBold() },
+      { new(Key.I, Ctrl: true), () => ToggleItalics() },
+      { new(Key.U, Ctrl: true), () => ToggleUnderlining() },
+
+      { new(Key.C, Ctrl: true), () => CopyToClipboard() },
+      { new(Key.X, Ctrl: true), () => CutToClipboard() },
+      { new(Key.V, Ctrl: true), () => PasteFromClipboard() },
+      { new(Key.V, Ctrl: true, Shift: true), () => PasteFromClipboardAsPlainText() },
+
+      { new(Key.Z, Ctrl: true), () =>
+         {
+            if (IsReadOnly) return;
+            FlowDoc.Undo();
+         }
+      },
+
+      { new(Key.A, Ctrl: true), () => FlowDoc.SelectAll() },
+      { new(Key.K, Ctrl: true), () => OpenHyperlinkPopup() },
+
+      { new(Key.Delete, Ctrl: true), () =>
+         {
+            if (IsReadOnly) return;
+            FlowDoc.DeleteWord(false);
+         }
+      },
+
+      { new(Key.Back, Ctrl: true), () =>
+         {
+            if (IsReadOnly) return;
+            FlowDoc.DeleteWord(true);
+         }
+      },
+
+      // Ctrl navigation
+      { new(Key.Home, Ctrl: true), () =>
+         {
+            FlowDoc.MoveToDocStart();
+            FlowDocSV.ScrollToHome();
+         }
+      },
+
+      { new(Key.Home, Ctrl: true, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionToDocStart();
+         }
+      },
+
+      { new(Key.End, Ctrl: true), () =>
+         {
+            FlowDoc.MoveToDocEnd();
+         }
+      },
+
+      { new(Key.End, Ctrl: true, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionToDocEnd();
+         }
+      },
+
+      { new(Key.Right, Ctrl: true), () =>
+         {
+            FlowDoc.MoveRightWord();
+         }
+      },
+
+      { new(Key.Right, Ctrl: true, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionRightWord();
+         }
+      },
+
+      { new(Key.Left, Ctrl: true), () =>
+         {
+            FlowDoc.MoveLeftWord();
+         }
+      },
+
+      { new(Key.Left, Ctrl: true, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionLeftWord();
+         }
+      },
+
+      // Normal keys
+      { new(Key.Escape), () =>
+         {
+            if (HyperlinkPopupOpen)
+               CloseHyperlinkPopup();
+            else if (PreeditOverlay.IsVisible)
+               HideIMEOverlay();
+         }
+      },
+
+      { new(Key.Tab), () =>
+         {
+            if (FlowDoc.Selection.GetStartPar() is Paragraph p && p.IsTableCellBlock)
+            {
+               if (FlowDoc.GetNextParagraph(p) is Paragraph nextPar)
+                  FlowDoc.Select(nextPar.StartInDoc, 0);
+            }
+            else
+            {
+               InsertTab();
+            }
+         }
+      },
+
+      { new(Key.Tab, Shift: true), () =>
+         {
+            if (FlowDoc.Selection.GetStartPar() is Paragraph p && p.IsTableCellBlock)
+            {
+               if (FlowDoc.GetPreviousParagraph(p) is Paragraph prevPar)
+                  FlowDoc.Select(prevPar.StartInDoc, 0);
+            }
+            else
+            {
+               InsertTab();
+            }
+         }
+      },
+
+      { new(Key.Enter), () =>
+         {
+            InsertParagraph();
+         }
+      },
+
+      { new(Key.Enter, Shift: true), () =>
+         {
+            if (LineBreakOnShiftEnter)
+               InsertLineBreak();
+            else
+               InsertParagraph();
+         }
+      },
+
+      { new(Key.Home), () =>
+         {
+            FlowDoc.MoveToStartOfLine(false);
+         }
+      },
+
+      { new(Key.Home, Shift: true), () =>
+         {
+            FlowDoc.MoveToStartOfLine(true);
+         }
+      },
+
+      { new(Key.End), () =>
+         {
+            FlowDoc.MoveToEndOfLine(false);
+         }
+      },
+
+      { new(Key.End, Shift: true), () =>
+         {
+            FlowDoc.MoveToEndOfLine(true);
+         }
+      },
+
+      { new(Key.Right), () =>
+         {
+            FlowDoc.MoveSelectionRight();
+            FlowDoc.ResetInsertFormatting();
+         }
+      },
+
+      { new(Key.Right, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionRight();
+            FlowDoc.ResetInsertFormatting();
+         }
+      },
+
+      { new(Key.Left), () =>
+         {
+            FlowDoc.MoveSelectionLeft();
+            FlowDoc.ResetInsertFormatting();
+         }
+      },
+
+      { new(Key.Left, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionLeft();
+            FlowDoc.ResetInsertFormatting();
+         }
+      },
+
+      { new(Key.Up), () =>
+         {
+            FlowDoc.MoveSelectionUp(false);
+         }
+      },
+
+      { new(Key.Up, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionUp();
+         }
+      },
+
+      { new(Key.Down), () =>
+         {
+            FlowDoc.MoveSelectionDown(true);
+         }
+      },
+
+      { new(Key.Down, Shift: true), () =>
+         {
+            FlowDoc.ExtendSelectionDown();
+         }
+      },
+
+      { new(Key.Back), () =>
+         {
+            PerformDelete(true);
+         }
+      },
+
+      { new(Key.Delete), () =>
+         {
+            PerformDelete(false);
+         }
+      },
+
+      { new(Key.PageDown), () =>
+         {
+            MovePage(1, false);
+         }
+      },
+
+      { new(Key.PageDown, Shift: true), () =>
+         {
+            MovePage(1, true);
+         }
+      },
+
+      { new(Key.PageUp), () =>
+         {
+            MovePage(-1, false);
+         }
+      },
+
+      { new(Key.PageUp, Shift: true), () =>
+         {
+            MovePage(-1, true);
+         }
+      },
+   };
+
+   private static KeyCombo GetCombo(KeyEventArgs e) =>
+      new(
+         e.Key,
+         Ctrl: e.KeyModifiers.HasFlag(KeyModifiers.Control),
+         Shift: e.KeyModifiers.HasFlag(KeyModifiers.Shift),
+         Alt: e.KeyModifiers.HasFlag(KeyModifiers.Alt)
+      );
+
+   private bool TryHandleKeyAction(KeyEventArgs e)
+   {
+      if (KeyActions.TryGetValue(GetCombo(e), out var action))
+      {
+         action();
+         e.Handled = true;
+         return true;
+      }
+
+      return false;
+   }
 
    private void RichTextBox_KeyDown(object? sender, KeyEventArgs e)
    {
+      TryHandleKeyAction(e);
 
-      if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
-      {
-         e.Handled = true;
-
-         if (!(e.KeyModifiers.HasFlag(KeyModifiers.Alt) || e.KeyModifiers.HasFlag(KeyModifiers.Shift)))
-         {
-            switch (e.Key)
-            {
-               case Key.I:
-                  ToggleItalics();
-                  break;
-
-               case Key.B:
-                  ToggleBold();
-                  break;
-
-               case Key.U:
-                  ToggleUnderlining();
-                  break;
-
-               case Key.C:
-                  CopyToClipboard();
-                  break;
-
-               case Key.X:
-                  CutToClipboard();
-                  break;
-
-               case Key.V:
-                  PasteFromClipboard();
-                  break;
-
-               case Key.Z:
-                  if (IsReadOnly) return;
-                  FlowDoc.Undo();
-                  break;
-
-               case Key.A:
-                  FlowDoc.SelectAll();
-                  break;
-
-               case Key.K:
-                  OpenHyperlinkPopup();
-                  break;
-
-               case Key.Delete:
-                  if (IsReadOnly) return;
-                  FlowDoc.DeleteWord(false);
-                  break;
-
-               case Key.Back:
-                  FlowDoc.DeleteWord(true);
-                  break;
-
-            }
-         }
-
-         switch (e.Key)
-         {
-
-            case Key.Home: // Ctrl-Home / Ctrl-Shift-Home
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionToDocStart();
-               else
-               {
-                  FlowDoc.MoveToDocStart();
-                  FlowDocSV.ScrollToHome();
-               }
-               break;
-
-            case Key.End: // Ctrl-End / Ctrl-Shift-End
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionToDocEnd();
-               else
-                  FlowDoc.MoveToDocEnd();
-               break;
-
-            case Key.Right:
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionRightWord();
-               else
-                  FlowDoc.MoveRightWord();
-               break;
-
-            case Key.Left:
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionLeftWord();
-               else
-                  FlowDoc.MoveLeftWord();
-               break;
-         }
-      }
-
-      else
-      {
-         switch (e.Key)
-         {
-            case Key.Escape:
-               if (HyperlinkPopupOpen)
-                  CloseHyperlinkPopup();
-               else if (PreeditOverlay.IsVisible)
-                  HideIMEOverlay();
-               break;
-
-            case Key.Tab:
-               e.Handled = true;
-               if (FlowDoc.Selection.GetStartPar() is Paragraph p && p.IsTableCellBlock)
-               {
-                  if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  {
-                     if (FlowDoc.GetPreviousParagraph(p) is Paragraph prevPar)
-                        FlowDoc.Select(prevPar.StartInDoc, 0);
-                  }
-                  else
-                  {
-                     if (FlowDoc.GetNextParagraph(p) is Paragraph nextPar)
-                        FlowDoc.Select(nextPar.StartInDoc, 0);
-                  }
-               }
-               else
-                  InsertTab();
-               break;
-
-            case Key.Enter:
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-               {
-                  if (LineBreakOnShiftEnter)
-                     InsertLineBreak();
-                  else
-                     InsertParagraph();
-               }
-               else
-                  InsertParagraph();
-               break;
-            case Key.Home:
-               FlowDoc.MoveToStartOfLine(e.KeyModifiers.HasFlag(KeyModifiers.Shift));
-               break;
-
-            case Key.End:
-               FlowDoc.MoveToEndOfLine(e.KeyModifiers.HasFlag(KeyModifiers.Shift));
-               break;
-
-            case Key.Right:
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionRight();
-               else
-                  FlowDoc.MoveSelectionRight();
-               FlowDoc.ResetInsertFormatting();
-               break;
-
-            case Key.Left:
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionLeft();
-               else
-                  FlowDoc.MoveSelectionLeft();
-               FlowDoc.ResetInsertFormatting();
-               break;
-
-            case Key.Up:
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionUp();
-               else
-                  FlowDoc.MoveSelectionUp(false);
-               break;
-
-            case Key.Down:
-               if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-                  FlowDoc.ExtendSelectionDown();
-               else
-                  FlowDoc.MoveSelectionDown(true);
-               break;
-
-            case Key.Back:
-               PerformDelete(true);
-               break;
-
-            case Key.Delete:
-               PerformDelete(false);
-               break;
-
-            case Key.PageDown:
-               MovePage(1, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
-               break;
-
-            case Key.PageUp:
-               MovePage(-1, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
-               break;
-
-         }
-
-         RtbVm.CaretVisible = (RtbVm.FlowDoc.Selection.Length == 0);
-         if (client != null)
-            UpdatePreeditOverlay();
-
-      }
-
-
+      RtbVm.CaretVisible = (RtbVm.FlowDoc.Selection.Length == 0);
+      if (client != null)
+         UpdatePreeditOverlay();
    }
-
-
-
 }
-
-

--- a/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
@@ -11,129 +11,132 @@ namespace AvRichTextBox;
 
 public partial class RichTextBox
 {
-   private void ToggleItalics()
-   {
-      if (IsReadOnly) return;
-      FlowDoc.ToggleItalic();
+    private void ToggleItalics()
+    {
+        if (IsReadOnly) return;
+        FlowDoc.ToggleItalic();
 
-   }
+    }
 
-   private void ToggleBold()
-   {
-      if (IsReadOnly) return;
-      FlowDoc.ToggleBold();
+    private void ToggleBold()
+    {
+        if (IsReadOnly) return;
+        FlowDoc.ToggleBold();
 
-   }
+    }
 
-   private void ToggleUnderlining()
-   {
-      if (IsReadOnly) return;
-      FlowDoc.ToggleUnderlining();
+    private void ToggleUnderlining()
+    {
+        if (IsReadOnly) return;
+        FlowDoc.ToggleUnderlining();
 
-   }
+    }
 
    private void CopyToClipboard()
    {
       if (DisableUserCopy) return;
 
-      var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
-      if (clipboard == null) return;
-      //create rtf string
-      List<IEditable> newInlines = FlowDoc.GetRangeInlines(FlowDoc.Selection);
-      string rtfString = RtfConversions.GetRtfFromInlines(newInlines);
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard == null) return;
+        //create rtf string
+        List<IEditable> newInlines = FlowDoc.GetRangeInlines(FlowDoc.Selection);
+        string rtfString = RtfConversions.GetRtfFromInlines(newInlines);
 
-      var dataTransfer = new DataTransfer();
+        var dataTransfer = new DataTransfer();
 
-      // Rtf format
-      var richTextFormat = DataFormat.CreateBytesPlatformFormat("Rich Text Format");
-      byte[] rtfbytes = Encoding.ASCII.GetBytes(rtfString + "\0");
-      dataTransfer.Add(DataTransferItem.Create(richTextFormat, rtfbytes));
+        // Rtf format
+        var richTextFormat = DataFormat.CreateBytesPlatformFormat("Rich Text Format");
+        byte[] rtfbytes = Encoding.ASCII.GetBytes(rtfString + "\0");
+        dataTransfer.Add(DataTransferItem.Create(richTextFormat, rtfbytes));
 
-      // Plain text
-      dataTransfer.Add(DataTransferItem.CreateText(FlowDoc.Selection.GetText()));
+        // Plain text
+        dataTransfer.Add(DataTransferItem.CreateText(FlowDoc.Selection.GetText()));
 
-      _ = clipboard.SetDataAsync(dataTransfer);
+        _ = clipboard.SetDataAsync(dataTransfer);
 
-   }
+    }
 
-   readonly static DataFormat<byte[]> richTextFormat = DataFormat.CreateBytesPlatformFormat("Rich Text Format");
+    readonly static DataFormat<byte[]> richTextFormat = DataFormat.CreateBytesPlatformFormat("Rich Text Format");
 
 
-   private void PasteFromClipboardAsPlainText() => PasteFromClipboard(plainTextOnly: true);
+    private void PasteFromClipboardAsPlainText() => PasteFromClipboard(plainTextOnly: true);
 
-   private async void PasteFromClipboard(bool plainTextOnly = false)
-   {
-      if (IsReadOnly) return;
-      if (FlowDoc.Selection.StartInline is not IEditable startInline) return;
+    private async void PasteFromClipboard(bool plainTextOnly = false)
+    {
+        if (IsReadOnly) return;
+        if (FlowDoc.Selection.StartInline is not IEditable startInline) return;
 
-      var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
-      if (clipboard == null) return;
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard == null) return;
 
-      // Get paste location properties
-      int originalSelectionStart = FlowDoc.Selection.Start;
-      int originalSelectionEnd = FlowDoc.Selection.End;
-      TextRange insertRange = FlowDoc.Selection;
-      List<Paragraph> originalRangeParagraphs = FlowDoc.GetOverlappingParagraphsInRange(insertRange).ConvertAll(op => op.FullClone());
-      int deleteRangeLength = insertRange.Length;
-      Paragraph startPar = insertRange.StartParagraph;
-      int insertParIndex = FlowDoc.Blocks.IndexOf(startPar);
-      bool firstParEmpty = startPar.Inlines[0] is EditableRun erun && erun.Text == "";
-      int pastedTextLength = 0;
-      List<int> addedBlockIds = [];
-      bool firstParWasDeleted = startPar.StartInDoc == originalSelectionStart && startPar.EndInDoc <= originalSelectionEnd && !firstParEmpty;     
-      bool addUndo = true;
-      bool contentPasted = false;
+        // Get paste location properties
+        int originalSelectionStart = FlowDoc.Selection.Start;
+        int originalSelectionEnd = FlowDoc.Selection.End;
+        TextRange insertRange = FlowDoc.Selection;
+        List<Paragraph> originalRangeParagraphs = FlowDoc.GetOverlappingParagraphsInRange(insertRange).ConvertAll(op => op.FullClone());
+        int deleteRangeLength = insertRange.Length;
+        Paragraph startPar = insertRange.StartParagraph;
+        int insertParIndex = FlowDoc.Blocks.IndexOf(startPar);
+        bool firstParEmpty = startPar.Inlines[0] is EditableRun erun && erun.Text == "";
+        int pastedTextLength = 0;
+        List<int> addedBlockIds = [];
+        bool firstParWasDeleted = startPar.StartInDoc == originalSelectionStart && startPar.EndInDoc <= originalSelectionEnd && !firstParEmpty;
+        bool addUndo = true;
+        bool contentPasted = false;
 
-      FlowDoc.disableRunTextUndo = true;
+        FlowDoc.disableRunTextUndo = true;
 
-      // Get clipboard content
-      if (!plainTextOnly && await clipboard.TryGetValueAsync(richTextFormat) is byte[] rtfbytes)
-      {
-         pastedTextLength = FlowDoc.InsertRTF(rtfbytes, startPar, insertRange, insertParIndex, addedBlockIds);
-         contentPasted = true;
-      }
-      else if (!plainTextOnly && await clipboard.TryGetBitmapAsync() is Bitmap pasteBitmap)
-      {
-         Image pasteImage = new() { Source = pasteBitmap };
-         EditableInlineUIContainer newEIUC = new(pasteImage);
-         Paragraph newPar = new(FlowDoc);
-         newPar.Inlines.Add(newEIUC);
-         Paragraph extraPar = new(FlowDoc);
-         FlowDoc.Blocks.Insert(insertParIndex + 1, newPar);
-         FlowDoc.Blocks.Insert(insertParIndex + 2, extraPar);
-         addedBlockIds.Add(newPar.Id);
-         addedBlockIds.Add(extraPar.Id);
-         pastedTextLength = 2;
-         contentPasted = true;
-      }
-      else if (await clipboard.TryGetTextAsync() is string pasteText)
-      {
-         FlowDoc.disableRunTextUndo = true;
-         pastedTextLength = pasteText.Length;
-         FlowDoc.Selection.Text = pasteText;
-         FlowDoc.disableRunTextUndo = false;
-         contentPasted = true;
-         addUndo = true;
-      }
+        // Get clipboard content
+        if (!plainTextOnly && await clipboard.TryGetValueAsync(richTextFormat) is byte[] rtfbytes)
+        {
+            pastedTextLength = FlowDoc.InsertRTF(rtfbytes, startPar, insertRange, insertParIndex, addedBlockIds);
+            contentPasted = true;
+        }
+        else if (!plainTextOnly && await clipboard.TryGetBitmapAsync() is Bitmap pasteBitmap)
+        {
+            Image pasteImage = new() { Source = pasteBitmap };
+            EditableInlineUIContainer newEIUC = new(pasteImage);
+            Paragraph newPar = new(FlowDoc);
+            newPar.Inlines.Add(newEIUC);
+            Paragraph extraPar = new(FlowDoc);
+            FlowDoc.Blocks.Insert(insertParIndex + 1, newPar);
+            FlowDoc.Blocks.Insert(insertParIndex + 2, extraPar);
+            addedBlockIds.Add(newPar.Id);
+            addedBlockIds.Add(extraPar.Id);
+            pastedTextLength = 2;
+            contentPasted = true;
+        }
+        else if (await clipboard.TryGetTextAsync() is string pasteText)
+        {
+            FlowDoc.disableRunTextUndo = true;
+            pastedTextLength = pasteText.Length;
+            if (plainTextOnly)
+                FlowDoc.SetRangeToText(insertRange, pasteText, copyFormatting: false);
+            else
+                FlowDoc.Selection.Text = pasteText;
+            FlowDoc.disableRunTextUndo = false;
+            contentPasted = true;
+            addUndo = true;
+        }
 
-      FlowDoc.disableRunTextUndo = false;
+        FlowDoc.disableRunTextUndo = false;
 
-      //Update based on pasted content
-      if (contentPasted)
-      {
+        //Update based on pasted content
+        if (contentPasted)
+        {
 
-         if (addUndo)
-            FlowDoc.Undos.Add(new PasteUndo(originalRangeParagraphs, insertParIndex, FlowDoc, originalSelectionStart, deleteRangeLength - pastedTextLength, firstParEmpty, addedBlockIds, firstParWasDeleted));
+            if (addUndo)
+                FlowDoc.Undos.Add(new PasteUndo(originalRangeParagraphs, insertParIndex, FlowDoc, originalSelectionStart, deleteRangeLength - pastedTextLength, firstParEmpty, addedBlockIds, firstParWasDeleted));
 
-         this.DocIC.UpdateLayout();
+            this.DocIC.UpdateLayout();
 
-         FlowDoc.UpdateBlockAndInlineStarts(insertParIndex);
-         FlowDoc.UpdateSelection();
-         FlowDoc.UpdateTextRanges(originalSelectionStart, pastedTextLength - deleteRangeLength);
+            FlowDoc.UpdateBlockAndInlineStarts(insertParIndex);
+            FlowDoc.UpdateSelection();
+            FlowDoc.UpdateTextRanges(originalSelectionStart, pastedTextLength - deleteRangeLength);
 
-         FlowDoc.SelectionExtendMode = ExtendMode.ExtendModeNone;
+            FlowDoc.SelectionExtendMode = ExtendMode.ExtendModeNone;
 
-         CreateClient();
+            CreateClient();
 
          FlowDoc.RestoreCaret(originalSelectionStart + pastedTextLength);
 
@@ -145,12 +148,12 @@ public partial class RichTextBox
       }
    }
 
-   private void CutToClipboard()
-   {
-      if (IsReadOnly) return;
-      CopyToClipboard();
-      PerformDelete(false);
-   }
+    private void CutToClipboard()
+    {
+        if (IsReadOnly) return;
+        CopyToClipboard();
+        PerformDelete(false);
+    }
 
 
 }

--- a/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
@@ -59,8 +59,6 @@ public partial class RichTextBox
     readonly static DataFormat<byte[]> richTextFormat = DataFormat.CreateBytesPlatformFormat("Rich Text Format");
 
 
-    private void PasteFromClipboardAsPlainText() => PasteFromClipboard(plainTextOnly: true);
-
     private async void PasteFromClipboard(bool plainTextOnly = false)
     {
         if (IsReadOnly) return;

--- a/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_RunFormatting.cs
@@ -59,7 +59,9 @@ public partial class RichTextBox
    readonly static DataFormat<byte[]> richTextFormat = DataFormat.CreateBytesPlatformFormat("Rich Text Format");
 
 
-   private async void PasteFromClipboard()
+   private void PasteFromClipboardAsPlainText() => PasteFromClipboard(plainTextOnly: true);
+
+   private async void PasteFromClipboard(bool plainTextOnly = false)
    {
       if (IsReadOnly) return;
       if (FlowDoc.Selection.StartInline is not IEditable startInline) return;
@@ -67,7 +69,7 @@ public partial class RichTextBox
       var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
       if (clipboard == null) return;
 
-      //get paste location properties
+      // Get paste location properties
       int originalSelectionStart = FlowDoc.Selection.Start;
       int originalSelectionEnd = FlowDoc.Selection.End;
       TextRange insertRange = FlowDoc.Selection;
@@ -78,20 +80,19 @@ public partial class RichTextBox
       bool firstParEmpty = startPar.Inlines[0] is EditableRun erun && erun.Text == "";
       int pastedTextLength = 0;
       List<int> addedBlockIds = [];
-      bool firstParWasDeleted = startPar.StartInDoc == originalSelectionStart && startPar.EndInDoc <= originalSelectionEnd && !firstParEmpty;
+      bool firstParWasDeleted = startPar.StartInDoc == originalSelectionStart && startPar.EndInDoc <= originalSelectionEnd && !firstParEmpty;     
       bool addUndo = true;
       bool contentPasted = false;
 
       FlowDoc.disableRunTextUndo = true;
 
-      //Get clipboard content
-      if (await clipboard.TryGetValueAsync(richTextFormat) is byte[] rtfbytes)
+      // Get clipboard content
+      if (!plainTextOnly && await clipboard.TryGetValueAsync(richTextFormat) is byte[] rtfbytes)
       {
          pastedTextLength = FlowDoc.InsertRTF(rtfbytes, startPar, insertRange, insertParIndex, addedBlockIds);
          contentPasted = true;
       }
-
-      else if (await clipboard.TryGetBitmapAsync() is Bitmap pasteBitmap)
+      else if (!plainTextOnly && await clipboard.TryGetBitmapAsync() is Bitmap pasteBitmap)
       {
          Image pasteImage = new() { Source = pasteBitmap };
          EditableInlineUIContainer newEIUC = new(pasteImage);
@@ -105,7 +106,6 @@ public partial class RichTextBox
          pastedTextLength = 2;
          contentPasted = true;
       }
-
       else if (await clipboard.TryGetTextAsync() is string pasteText)
       {
          FlowDoc.disableRunTextUndo = true;
@@ -121,18 +121,18 @@ public partial class RichTextBox
       //Update based on pasted content
       if (contentPasted)
       {
-         
+
          if (addUndo)
             FlowDoc.Undos.Add(new PasteUndo(originalRangeParagraphs, insertParIndex, FlowDoc, originalSelectionStart, deleteRangeLength - pastedTextLength, firstParEmpty, addedBlockIds, firstParWasDeleted));
 
          this.DocIC.UpdateLayout();
-         
+
          FlowDoc.UpdateBlockAndInlineStarts(insertParIndex);
          FlowDoc.UpdateSelection();
          FlowDoc.UpdateTextRanges(originalSelectionStart, pastedTextLength - deleteRangeLength);
 
          FlowDoc.SelectionExtendMode = ExtendMode.ExtendModeNone;
-         
+
          CreateClient();
 
          FlowDoc.RestoreCaret(originalSelectionStart + pastedTextLength);


### PR DESCRIPTION
This PR adds the functionality to paste as plain text with shortcut CTRL+SHIFT+V or using the context menu.

~~If the text where the clipboard-data is inserted at has already formatting, than this formatting will not be applied to the inserted text. This is how for example LibreOffice Writer works, but I'm open to change this.~~
**Update:** That's actually not correct. Existing formatting is applied in LibreOffice Writer. ~~Should the changes in commit [b7ea0e1](https://github.com/cuikp/AvRichTextBox/pull/37/commits/b7ea0e11c5454f80af96fa36233b605458f84a92) be undone?~~
I reverted the changes, so it like most users probably expect it to work (use formatting that the current text in the control has). A way to clear formatting could be added in addition.


The addUndo variable and if-clause has been removed, because addUndo is always true. This change can be reverted, if there is a reason to keep it, of course.