### PR TITLE
Html loading/saving improvements

### DIFF
--- a/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/ContentToHtml.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/ContentToHtml.cs
@@ -149,8 +149,22 @@ internal static partial class HtmlConversions
 
       foreach (IEditable ied in p.Inlines)
       {
-         switch (ied)
+          switch (ied)
          {
+            case EditableHyperlink elink:
+               {
+                  if (!string.IsNullOrEmpty(elink.Text))
+                  {
+                     var aNode = hdoc.CreateElement("a");
+                     aNode.SetAttributeValue("href", elink.NavigateUri);
+                     aNode.InnerHtml = WebUtility.HtmlEncode(elink.Text ?? "");
+                     aNode.SetAttributeValue("style", GetInlineStyle(elink));
+                     parnode.AppendChild(aNode);
+                     hasContent = true;
+                  }
+                  break;
+               }
+
             case EditableRun erun:
                {
                   if (!string.IsNullOrEmpty(erun.Text))

--- a/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
@@ -374,10 +374,10 @@ internal static partial class HtmlConversions
                         IsVisible = true,
                      };
 
-                     if (node.GetAttributeValue("width", null!) is string w && double.TryParse(w, out var width))
+                     if (node.GetAttributeValue("width", null!) is string w && double.TryParse(w, NumberStyles.Float, CultureInfo.InvariantCulture, out var width))
                         img.Width = width;
 
-                     if (node.GetAttributeValue("height", null!) is string h && double.TryParse(h, out var height))
+                     if (node.GetAttributeValue("height", null!) is string h && double.TryParse(h, NumberStyles.Float, CultureInfo.InvariantCulture, out var height))
                         img.Height = height;
 
                      par.Inlines.Add(new EditableInlineUIContainer(img));
@@ -484,7 +484,7 @@ internal static partial class HtmlConversions
                break;
 
             case "font-size":
-               if (double.TryParse(kvp.Value.Replace("px", ""), out var size))
+               if (double.TryParse(kvp.Value.Replace("px", ""), NumberStyles.Float, CultureInfo.InvariantCulture, out var size))
                   formatting.FontSize = size;
                break;
 
@@ -554,7 +554,7 @@ internal static partial class HtmlConversions
 
                if (par.Inlines.Count > 0)
                {
-                  double lineHeight = Double.TryParse(kvp.Value.Replace("px", ""), out var px) ? px : 0;
+                  double lineHeight = double.TryParse(kvp.Value.Replace("px", ""), NumberStyles.Float, CultureInfo.InvariantCulture, out var px) ? px : 0;
                   //double maxInlineHeight = par.Inlines.Max(ilh => ilh.InlineHeight);
                   //par.LineHeight = LineHeightToLineSpacing(lineHeight, maxInlineHeight);
                   par.LineHeight = lineHeight;
@@ -642,7 +642,6 @@ internal static partial class HtmlConversions
 
    private static readonly Regex Rgba = new(@"^\s*rgba?\(\s*(?<r>\d{1,3})\s*,\s*(?<g>\d{1,3})\s*,\s*(?<b>\d{1,3})\s*(?:,\s*(?<a>[-+]?\d*\.?\d+)\s*)?\)\s*;?\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-   private static ColorConverter colConverter = new();
 
    private static SolidColorBrush? ParseCssColor(string cssColor)
    {
@@ -661,7 +660,9 @@ internal static partial class HtmlConversions
          double aD = 1.0;
          if (m.Groups["a"].Success &&
              !double.TryParse(m.Groups["a"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out aD))
+         {
             return null;
+         }
 
          aD = Math.Clamp(aD, 0.0, 1.0);
          var a = (byte)Math.Round(aD * 255.0);
@@ -672,8 +673,8 @@ internal static partial class HtmlConversions
       // hex (#RGB, #RRGGBB, #AARRGGBB) and named colors (Red, etc.)
       try
       {
-         var obj = colConverter.ConvertFromString(cssColor.TrimEnd(';'));
-         if (obj is Avalonia.Media.Color c) return new SolidColorBrush(c);
+         if (Avalonia.Media.Color.TryParse(cssColor.TrimEnd(';'), out var avColor))
+            return new SolidColorBrush(avColor);
       }
       catch { }
 

--- a/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/HtmlConversions/HtmlToContent.cs
@@ -437,11 +437,41 @@ internal static partial class HtmlConversions
                AddInlinesFromNode(node, par, subFormatting);
                break;
 
-            default:
-               // For any unrecognized inline element, recurse into its children
-               // preserving current formatting
-               AddInlinesFromNode(node, par, formatting);
-               break;
+             case "a":
+                var href = node.GetAttributeValue("href", "");
+                if (!string.IsNullOrEmpty(href))
+                {
+                   string linkText = WebUtility.HtmlDecode(node.InnerText);
+                   if (!string.IsNullOrEmpty(linkText))
+                   {
+                      var hyperlink = new EditableHyperlink(linkText, href);
+                      var aFormatting = formatting.Clone();
+                      ApplyStyleToFormatting(node.GetAttributeValue("style", ""), aFormatting);
+                      // Apply formatting except foreground/decorations (EditableHyperlink forces those)
+                      hyperlink.FontWeight = aFormatting.FontWeight;
+                      hyperlink.FontStyle = aFormatting.FontStyle;
+                      hyperlink.BaselineAlignment = aFormatting.BaselineAlignment;
+                      if (aFormatting.FontFamily != null)
+                         hyperlink.FontFamily = aFormatting.FontFamily;
+                      if (aFormatting.FontSize.HasValue)
+                         hyperlink.FontSize = aFormatting.FontSize.Value;
+                      if (aFormatting.Background != null)
+                         hyperlink.Background = aFormatting.Background;
+                      par.Inlines.Add(hyperlink);
+                   }
+                }
+                else
+                {
+                   // No href — treat as generic inline, recurse preserving formatting
+                   AddInlinesFromNode(node, par, formatting);
+                }
+                break;
+
+             default:
+                // For any unrecognized inline element, recurse into its children
+                // preserving current formatting
+                AddInlinesFromNode(node, par, formatting);
+                break;
          }
       }
    }

--- a/DemoApp_AvRichtextBox/NumericSpinner/NumericSpinner.axaml.cs
+++ b/DemoApp_AvRichtextBox/NumericSpinner/NumericSpinner.axaml.cs
@@ -156,13 +156,15 @@ public class DoubleToStringConverter : IValueConverter
 {
    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
    {
-      return value?.ToString() ?? "";
+      if (value is double d)
+         return d.ToString(CultureInfo.InvariantCulture);
+      return "";
    }
 
    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
    {
-      if (double.TryParse(value as string, out double result))
+      if (double.TryParse(value as string, NumberStyles.Float, CultureInfo.InvariantCulture, out double result))
          return result;
-      return 0; // Default fallback
+      return 0.0; // Default fallback
    }
 }


### PR DESCRIPTION
- Uses invariant culture when parsing double (otherwise it can lead to wrong values in cultures that don't use point as decimal separator (in my case I couldn't load the html sample properly for example)
- Changes when parsing colors - fixes issues loading colors in html doc
- Support loading and saving hyperlinks in html content