### PR TITLE
UI to add/edit/delete hyperlinks

### DIFF
--- a/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
@@ -96,17 +96,41 @@ public partial class FlowDocument
       if (GetStartInline(Selection.Start) is not IEditable insertAfterInline)
       { disableRunTextUndo = false; return; }
 
-      int charPosInInline = GetCharPosInInline(insertAfterInline, Selection.Start);
+      IEditable leftRun;
+      int insertIdx;
 
-      // Split the run at the caret so we can inject the hyperlink inline
-      List<IEditable> splitRuns = SplitRunAtPos(Selection.Start, insertAfterInline, charPosInInline);
+      if (insertAfterInline.IsLineBreak || insertAfterInline is EditableInlineUIContainer)
+      {
+         // Cannot split a line break or UI container — insert the hyperlink before it instead.
+         int nonSplittableIdx = startPar.Inlines.IndexOf(insertAfterInline);
+         if (nonSplittableIdx > 0)
+         {
+            leftRun = startPar.Inlines[nonSplittableIdx - 1];
+         }
+         else
+         {
+            // No preceding inline exists; create an empty run as a left anchor.
+            var emptyAnchor = new EditableRun("") { MyParagraphId = startPar.Id, MyFlowDoc = this };
+            startPar.Inlines.Insert(0, emptyAnchor);
+            nonSplittableIdx = 1;
+            leftRun = emptyAnchor;
+         }
+         insertIdx = nonSplittableIdx;
+      }
+      else
+      {
+         int charPosInInline = GetCharPosInInline(insertAfterInline, Selection.Start);
 
-      IEditable leftRun = splitRuns[0];
-      int insertIdx = startPar.Inlines.IndexOf(leftRun) + 1;
+         // Split the run at the caret so we can inject the hyperlink inline
+         List<IEditable> splitRuns = SplitRunAtPos(Selection.Start, insertAfterInline, charPosInInline);
 
-      bool leftWasEmpty = leftRun.InlineText == "";
-      if (leftWasEmpty && splitRuns.Count > 1)
-         insertIdx--;
+         leftRun = splitRuns[0];
+         insertIdx = startPar.Inlines.IndexOf(leftRun) + 1;
+
+         bool leftWasEmpty = leftRun.InlineText == "";
+         if (leftWasEmpty && splitRuns.Count > 1)
+            insertIdx--;
+      }
 
       var newHyperlink = new EditableHyperlink(displayText, navigateUri)
       {
@@ -116,7 +140,8 @@ public partial class FlowDocument
 
       startPar.Inlines.Insert(insertIdx, newHyperlink);
 
-      if (leftWasEmpty && startPar.Inlines.Contains(leftRun))
+      if (insertAfterInline is not (EditableLineBreak or EditableInlineUIContainer) &&
+          leftRun.InlineText == "" && startPar.Inlines.Contains(leftRun))
          startPar.Inlines.Remove(leftRun);
 
       startPar.CallRequestInlinesUpdate();

--- a/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
@@ -1,0 +1,172 @@
+namespace AvRichTextBox;
+
+public partial class FlowDocument
+{
+   /// <summary>
+   /// Returns the hyperlink that contains (or starts at) the current selection start,
+   /// or null if the caret/selection is not inside a hyperlink.
+   /// </summary>
+   internal EditableHyperlink? GetHyperlinkAtSelection()
+   {
+      if (Selection.StartInline is EditableHyperlink hl)
+         return hl;
+
+      // Also check when caret is right at the boundary after a hyperlink
+      if (GetStartInline(Selection.Start) is EditableHyperlink hl2)
+         return hl2;
+
+      return null;
+   }
+
+   /// <summary>
+   /// Inserts a new hyperlink from the current selection, or updates the hyperlink
+   /// the caret is currently inside.
+   /// - If the caret is inside an existing hyperlink: update its text and URI in place.
+   /// - If there is a text selection: replace the selected text with a hyperlink.
+   /// - If there is no selection and no existing hyperlink: insert a new hyperlink with the given text.
+   /// </summary>
+   internal void InsertOrUpdateHyperlink(string displayText, string navigateUri)
+   {
+      if (string.IsNullOrWhiteSpace(navigateUri)) return;
+
+      // Normalize URI – add https:// scheme if none is present
+      if (!navigateUri.Contains("://") && !navigateUri.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
+         navigateUri = "https://" + navigateUri;
+
+      // ── Case 1: caret is inside an existing hyperlink ─────────────────────
+      if (GetHyperlinkAtSelection() is EditableHyperlink existingHyperlink)
+      {
+         Paragraph par = GetContainingParagraph(Selection.Start);
+         if (par == null) return;
+
+         disableRunTextUndo = true;
+
+         existingHyperlink.NavigateUri = navigateUri;
+
+         // Update display text only when it changed
+         if (existingHyperlink.Text != displayText)
+         {
+            int hlIdx = par.Inlines.IndexOf(existingHyperlink);
+            int oldLength = existingHyperlink.InlineLength;
+
+            existingHyperlink.Text = displayText;
+
+            par.CallRequestInlinesUpdate();
+            UpdateBlockAndInlineStarts(par);
+            int newLength = existingHyperlink.InlineLength;
+            UpdateTextRanges(par.StartInDoc + existingHyperlink.TextPositionOfInlineInParagraph,
+                             newLength - oldLength);
+         }
+         else
+         {
+            par.CallRequestInlinesUpdate();
+         }
+
+         disableRunTextUndo = false;
+         return;
+      }
+
+      // ── Case 2: text is selected → replace selection with hyperlink ────────
+      Paragraph? startPar = Selection.GetStartPar();
+      if (startPar == null) return;
+
+      disableRunTextUndo = true;
+
+      if (Selection.Length > 0)
+      {
+         // Delete the selected range and collect split-point info
+         var edgeIds = DeleteRange(Selection, false, false);
+         Selection.CollapseToStart();
+         SelectionExtendMode = ExtendMode.ExtendModeNone;
+      }
+
+      // Find where to insert after the possible delete
+      if (GetStartInline(Selection.Start) is not IEditable insertAfterInline)
+      {
+         disableRunTextUndo = false;
+         return;
+      }
+
+      startPar = GetContainingParagraph(Selection.Start);
+      if (startPar == null)
+      {
+         disableRunTextUndo = false;
+         return;
+      }
+
+      int charPosInInline = GetCharPosInInline(insertAfterInline, Selection.Start);
+
+      // Split the run at the insert position so we can inject the hyperlink inline
+      List<IEditable> splitRuns = SplitRunAtPos(Selection.Start, insertAfterInline, charPosInInline);
+
+      // splitRuns[0] is left part, splitRuns[1] is right part (may be same object if no split needed)
+      IEditable leftRun = splitRuns[0];
+      int insertIdx = startPar.Inlines.IndexOf(leftRun) + 1;
+
+      // Remove empty placeholder if the left run is empty
+      bool leftWasEmpty = leftRun.InlineText == "";
+      if (leftWasEmpty && splitRuns.Count > 1)
+         insertIdx--;  // insert before left empty run (will be removed below)
+
+      var newHyperlink = new EditableHyperlink(displayText, navigateUri)
+      {
+         MyParagraphId = startPar.Id,
+         MyFlowDoc = this,
+      };
+
+      startPar.Inlines.Insert(insertIdx, newHyperlink);
+
+      // Remove the empty left run if it was a zero-length leftover
+      if (leftWasEmpty && startPar.Inlines.Contains(leftRun))
+         startPar.Inlines.Remove(leftRun);
+
+      startPar.CallRequestInlinesUpdate();
+      UpdateBlockAndInlineStarts(startPar);
+      UpdateTextRanges(Selection.Start, displayText.Length);
+
+      // Move caret to end of inserted hyperlink
+      Select(Selection.Start + displayText.Length, 0);
+
+      disableRunTextUndo = false;
+   }
+
+   /// <summary>
+   /// Removes the hyperlink under/at the current selection and replaces it with a
+   /// plain EditableRun preserving the display text and font properties.
+   /// </summary>
+   internal void RemoveHyperlink()
+   {
+      if (GetHyperlinkAtSelection() is not EditableHyperlink hl) return;
+
+      Paragraph par = GetContainingParagraph(Selection.Start);
+      if (par == null) return;
+
+      disableRunTextUndo = true;
+
+      int hlIdx = par.Inlines.IndexOf(hl);
+      int caretPos = Selection.Start;
+
+      // Replace hyperlink with a plain run that has the same text
+      var replacement = new EditableRun(hl.Text ?? "")
+      {
+         FontFamily = hl.FontFamily,
+         FontWeight = hl.FontWeight,
+         FontStyle = hl.FontStyle,
+         FontSize = hl.FontSize,
+         Background = hl.Background,
+         BaselineAlignment = hl.BaselineAlignment,
+         MyParagraphId = par.Id,
+         MyFlowDoc = this,
+      };
+
+      par.Inlines[hlIdx] = replacement;
+
+      par.CallRequestInlinesUpdate();
+      UpdateBlockAndInlineStarts(par);
+
+      // Restore caret to approximately the same position
+      Select(caretPos, 0);
+
+      disableRunTextUndo = false;
+   }
+}

--- a/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
@@ -124,7 +124,7 @@ public partial class FlowDocument
       UpdateTextRanges(Selection.Start, displayText.Length);
 
       // Move caret to end of inserted hyperlink
-      Select(Selection.Start + displayText.Length, 0);
+      Select(origSelStart + displayText.Length, 0);
 
       disableRunTextUndo = false;
 

--- a/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Hyperlink.cs
@@ -33,80 +33,80 @@ public partial class FlowDocument
       if (!navigateUri.Contains("://") && !navigateUri.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
          navigateUri = "https://" + navigateUri;
 
-      // ── Case 1: caret is inside an existing hyperlink ─────────────────────
+      // ── Case 1: caret is inside an existing hyperlink → update in place ──────
       if (GetHyperlinkAtSelection() is EditableHyperlink existingHyperlink)
       {
          Paragraph par = GetContainingParagraph(Selection.Start);
          if (par == null) return;
 
+         // Snapshot before edit for undo
+         Paragraph parClone = par.FullClone();
+         int parIndex = Blocks.IndexOf(par);
+         int updateOrigSelStart = Selection.Start;
+         int oldLength = existingHyperlink.InlineLength;
+
          disableRunTextUndo = true;
 
          existingHyperlink.NavigateUri = navigateUri;
+         existingHyperlink.Text = displayText;
 
-         // Update display text only when it changed
-         if (existingHyperlink.Text != displayText)
-         {
-            int hlIdx = par.Inlines.IndexOf(existingHyperlink);
-            int oldLength = existingHyperlink.InlineLength;
+         par.CallRequestInlinesUpdate();
+         UpdateBlockAndInlineStarts(par);
 
-            existingHyperlink.Text = displayText;
+         int newLength = existingHyperlink.InlineLength;
+         int lengthDelta = newLength - oldLength;
 
-            par.CallRequestInlinesUpdate();
-            UpdateBlockAndInlineStarts(par);
-            int newLength = existingHyperlink.InlineLength;
-            UpdateTextRanges(par.StartInDoc + existingHyperlink.TextPositionOfInlineInParagraph,
-                             newLength - oldLength);
-         }
-         else
-         {
-            par.CallRequestInlinesUpdate();
-         }
+         if (lengthDelta != 0)
+            UpdateTextRanges(par.StartInDoc + existingHyperlink.TextPositionOfInlineInParagraph, lengthDelta);
 
          disableRunTextUndo = false;
+
+         Undos.Add(new HyperlinkParagraphUndo(parClone, parIndex, this, updateOrigSelStart, -lengthDelta));
          return;
       }
 
-      // ── Case 2: text is selected → replace selection with hyperlink ────────
+      // ── Case 2: insert new hyperlink (replace selection or insert at caret) ──
       Paragraph? startPar = Selection.GetStartPar();
       if (startPar == null) return;
+
+      // Snapshot the affected paragraphs before any edit for undo.
+      // When there is a selection that may span multiple paragraphs we need all of them.
+      List<Paragraph> affectedParClones = GetOverlappingParagraphsInRange(Selection).ConvertAll(p => p.FullClone());
+      int firstParIndex = Blocks.IndexOf(startPar);
+      int origSelStart = Selection.Start;
+      bool firstParWasDeleted = false;
 
       disableRunTextUndo = true;
 
       if (Selection.Length > 0)
       {
-         // Delete the selected range and collect split-point info
-         var edgeIds = DeleteRange(Selection, false, false);
+         // DeleteRange may collapse multiple paragraphs into one; track whether the first par is gone
+         bool firstParEmpty = startPar.Inlines.Count == 1 && startPar.Inlines[0] is EditableRun er && er.Text == "";
+         firstParWasDeleted = startPar.StartInDoc == Selection.Start && startPar.EndInDoc <= Selection.End && !firstParEmpty;
+
+         DeleteRange(Selection, false, false);
          Selection.CollapseToStart();
          SelectionExtendMode = ExtendMode.ExtendModeNone;
       }
 
-      // Find where to insert after the possible delete
-      if (GetStartInline(Selection.Start) is not IEditable insertAfterInline)
-      {
-         disableRunTextUndo = false;
-         return;
-      }
-
+      // Re-resolve the paragraph after possible deletion
       startPar = GetContainingParagraph(Selection.Start);
-      if (startPar == null)
-      {
-         disableRunTextUndo = false;
-         return;
-      }
+      if (startPar == null) { disableRunTextUndo = false; return; }
+
+      if (GetStartInline(Selection.Start) is not IEditable insertAfterInline)
+      { disableRunTextUndo = false; return; }
 
       int charPosInInline = GetCharPosInInline(insertAfterInline, Selection.Start);
 
-      // Split the run at the insert position so we can inject the hyperlink inline
+      // Split the run at the caret so we can inject the hyperlink inline
       List<IEditable> splitRuns = SplitRunAtPos(Selection.Start, insertAfterInline, charPosInInline);
 
-      // splitRuns[0] is left part, splitRuns[1] is right part (may be same object if no split needed)
       IEditable leftRun = splitRuns[0];
       int insertIdx = startPar.Inlines.IndexOf(leftRun) + 1;
 
-      // Remove empty placeholder if the left run is empty
       bool leftWasEmpty = leftRun.InlineText == "";
       if (leftWasEmpty && splitRuns.Count > 1)
-         insertIdx--;  // insert before left empty run (will be removed below)
+         insertIdx--;
 
       var newHyperlink = new EditableHyperlink(displayText, navigateUri)
       {
@@ -116,7 +116,6 @@ public partial class FlowDocument
 
       startPar.Inlines.Insert(insertIdx, newHyperlink);
 
-      // Remove the empty left run if it was a zero-length leftover
       if (leftWasEmpty && startPar.Inlines.Contains(leftRun))
          startPar.Inlines.Remove(leftRun);
 
@@ -128,6 +127,9 @@ public partial class FlowDocument
       Select(Selection.Start + displayText.Length, 0);
 
       disableRunTextUndo = false;
+
+      // undoEditOffset = -(displayText.Length) so Undo moves the selection back
+      Undos.Add(new HyperlinkParagraphUndo(affectedParClones, firstParIndex, this, origSelStart, -displayText.Length, firstParWasDeleted));
    }
 
    /// <summary>
@@ -141,12 +143,17 @@ public partial class FlowDocument
       Paragraph par = GetContainingParagraph(Selection.Start);
       if (par == null) return;
 
+      // Snapshot before edit for undo
+      Paragraph parClone = par.FullClone();
+      int parIndex = Blocks.IndexOf(par);
+      int caretPos = Selection.Start;
+      int hlLength = hl.InlineLength;
+
       disableRunTextUndo = true;
 
       int hlIdx = par.Inlines.IndexOf(hl);
-      int caretPos = Selection.Start;
 
-      // Replace hyperlink with a plain run that has the same text
+      // Replace hyperlink with a plain run preserving the display text and font properties
       var replacement = new EditableRun(hl.Text ?? "")
       {
          FontFamily = hl.FontFamily,
@@ -164,9 +171,11 @@ public partial class FlowDocument
       par.CallRequestInlinesUpdate();
       UpdateBlockAndInlineStarts(par);
 
-      // Restore caret to approximately the same position
       Select(caretPos, 0);
 
       disableRunTextUndo = false;
+
+      // The remove operation doesn't change the text length, so undoEditOffset = 0
+      Undos.Add(new HyperlinkParagraphUndo(parClone, parIndex, this, caretPos, 0));
    }
 }

--- a/AvRichTextBox/FlowDocument/FlowDocument_Insert.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Insert.cs
@@ -121,7 +121,28 @@ public partial class FlowDocument
       //if (Selection.StartInline is EditableInlineUIContainer or EditableHyperlink) return;
       if (Selection.StartInline is not IEditable startInline || startInline is EditableInlineUIContainer) return;
       
-      if (startInline is EditableHyperlink hyperlink && Selection.GetIsStartAtStartOfStartInline) return;
+      if (startInline is EditableHyperlink && Selection.GetIsStartAtStartOfStartInline)
+      {
+         // Caret is at the start of a hyperlink.
+         // If there is a non-hyperlink inline immediately before it, append text there instead.
+         // If the hyperlink is the first inline in the paragraph, insert a new plain run before it
+         // so the user can type text preceding the hyperlink.
+         int hyperlinkIdx = Selection.StartParagraph.Inlines.IndexOf(startInline);
+         if (hyperlinkIdx > 0 && Selection.StartParagraph.Inlines[hyperlinkIdx - 1] is EditableRun precedingRun)
+         {
+            startInline = precedingRun;
+         }
+         else if (hyperlinkIdx == 0)
+         {
+            var newRun = new EditableRun("");
+            Selection.StartParagraph.Inlines.Insert(0, newRun);
+            UpdateBlockAndInlineStarts(Selection.StartParagraph);
+            Selection.UpdateContextStart();
+            startInline = newRun;
+         }
+         else
+            return;
+      }
 
       if (insertText != null)
       {

--- a/AvRichTextBox/FlowDocument/FlowDocument_SelectionExtend.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_SelectionExtend.cs
@@ -286,10 +286,6 @@ public partial class FlowDocument
          }
       }
 
-      // skip special
-      if (GetStartInline(computedNext - 1) is EditableHyperlink hyperlink)
-         computedNext = Selection.StartParagraph.StartInDoc + hyperlink.TextPositionOfInlineInParagraph + hyperlink.InlineLength;
-
       return computedNext;
 
 
@@ -318,10 +314,6 @@ public partial class FlowDocument
       }
 
             
-      // skip special
-      if (GetStartInline(computedPrev - 1) is EditableHyperlink hyperlink)
-         computedPrev = Selection.StartParagraph.StartInDoc + hyperlink.TextPositionOfInlineInParagraph;
-
       return computedPrev;
 
    }

--- a/AvRichTextBox/RichTextBox/RichTextBox.axaml
+++ b/AvRichTextBox/RichTextBox/RichTextBox.axaml
@@ -73,14 +73,18 @@
 				<!-- The FlowDocument itself -->
 				<ItemsControl x:Name="DocIC" DataContext="{Binding FlowDoc}" VerticalAlignment="Top" ItemsSource="{Binding Blocks}" Margin="0" Padding="{Binding PagePadding}" >
 
-					<ItemsControl.ContextMenu>
-						<ContextMenu>
-							<MenuItem Header="Copy" Click="CopySelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
-							<MenuItem Header="Paste" Click="PasteSelectionMenuItem_Click" />
-							<MenuItem Header="Cut" Click="CutSelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
-							<MenuItem Header="Delete" Click="DeleteSelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
-						</ContextMenu>
-					</ItemsControl.ContextMenu>
+				<ItemsControl.ContextMenu>
+					<ContextMenu x:Name="DocContextMenu" Opening="DocContextMenu_Opening">
+						<MenuItem Header="Copy" Click="CopySelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
+						<MenuItem Header="Paste" Click="PasteSelectionMenuItem_Click" />
+						<MenuItem Header="Cut" Click="CutSelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
+						<MenuItem Header="Delete" Click="DeleteSelectionMenuItem_Click" IsEnabled="{Binding HasSelectedText}"/>
+						<Separator/>
+						<MenuItem x:Name="InsertHyperlinkMenuItem" Header="Insert Hyperlink" Click="InsertHyperlinkMenuItem_Click"/>
+						<MenuItem x:Name="EditHyperlinkMenuItem"   Header="Edit Hyperlink"   Click="EditHyperlinkMenuItem_Click"   IsVisible="False"/>
+						<MenuItem x:Name="RemoveHyperlinkMenuItem" Header="Remove Hyperlink" Click="RemoveHyperlinkMenuItem_Click" IsVisible="False"/>
+					</ContextMenu>
+				</ItemsControl.ContextMenu>
 
 					<ItemsControl.ItemsPanel>
 						<ItemsPanelTemplate>
@@ -160,10 +164,62 @@
 					</ItemsControl.ItemTemplate>
 				</ItemsControl>
 
-				<TextBlock x:Name="PreeditOverlay" Padding="4, 0, 4, 2" Height="24" FontSize="15" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="Black" Background="#DDDDDD" IsHitTestVisible="False" IsVisible="False"/>
-							
-				
-			</Grid>
+			<TextBlock x:Name="PreeditOverlay" Padding="4, 0, 4, 2" Height="24" FontSize="15" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="Black" Background="#DDDDDD" IsHitTestVisible="False" IsVisible="False"/>
+
+			<!-- Hyperlink insert/edit popup -->
+			<Popup x:Name="HyperlinkPopup"
+				   Placement="Bottom"
+				   PlacementTarget="{Binding ElementName=DocIC}"
+				   IsLightDismissEnabled="True">
+				<Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+						BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+						BorderThickness="1"
+						CornerRadius="4"
+						Padding="10"
+						BoxShadow="0 2 8 0 #40000000">
+					<StackPanel Orientation="Vertical" Spacing="8" Width="320"
+								KeyDown="HyperlinkPopup_KeyDown">
+
+						<!-- Title -->
+						<TextBlock x:Name="HyperlinkPopupTitle" Text="Insert Hyperlink" FontWeight="SemiBold" FontSize="13"/>
+
+						<!-- Text field -->
+						<StackPanel Orientation="Vertical" Spacing="3">
+							<TextBlock Text="Text" FontSize="12"/>
+							<TextBox x:Name="HyperlinkTextBox"
+									 PlaceholderText="Display text"
+									 FontSize="13"
+									 KeyDown="HyperlinkPopup_KeyDown"/>
+						</StackPanel>
+
+						<!-- URL field -->
+						<StackPanel Orientation="Vertical" Spacing="3">
+							<TextBlock Text="URL" FontSize="12"/>
+							<TextBox x:Name="HyperlinkUrlBox"
+									 PlaceholderText="https://"
+									 FontSize="13"
+									 KeyDown="HyperlinkPopup_KeyDown"/>
+						</StackPanel>
+
+						<!-- Buttons -->
+						<StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right">
+							<Button x:Name="HyperlinkDeleteButton"
+									Content="Remove Link"
+									Click="HyperlinkDeleteButton_Click"
+									IsVisible="False"/>
+							<Button x:Name="HyperlinkCancelButton"
+									Content="Cancel"
+									Click="HyperlinkCancelButton_Click"/>
+							<Button x:Name="HyperlinkOkButton"
+									Content="OK"
+									Click="HyperlinkOkButton_Click"/>
+						</StackPanel>
+
+					</StackPanel>
+				</Border>
+			</Popup>
+						
+		</Grid>
 		</ScrollViewer>
 
 		</LayoutTransformControl>

--- a/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
@@ -297,6 +297,17 @@ public partial class RichTextBox : UserControl
    }
 
    
+   // ── Context menu ─────────────────────────────────────────────────────────
+
+   private void DocContextMenu_Opening(object? sender, System.ComponentModel.CancelEventArgs e)
+   {
+      bool overHyperlink = FlowDoc.GetHyperlinkAtSelection() != null;
+
+      InsertHyperlinkMenuItem.IsVisible  = !overHyperlink;
+      EditHyperlinkMenuItem.IsVisible    =  overHyperlink;
+      RemoveHyperlinkMenuItem.IsVisible  =  overHyperlink;
+   }
+
    private void CopySelectionMenuItem_Click(object? sender, RoutedEventArgs e)
    {
       if (DisableUserCopy) return;

--- a/AvRichTextBox/RichTextBox/RichTextBox_HyperlinkEditing.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_HyperlinkEditing.cs
@@ -1,0 +1,130 @@
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace AvRichTextBox;
+
+public partial class RichTextBox
+{
+   // Popup state 
+
+   /// <summary>True while the hyperlink popup is open.</summary>
+   private bool HyperlinkPopupOpen => HyperlinkPopup?.IsOpen == true;
+
+   // Public entry points 
+
+   /// <summary>
+   /// Opens the hyperlink insert/edit popup.
+   /// Called from Ctrl+K, context menu "Insert Hyperlink" and context menu "Edit Hyperlink".
+   /// </summary>
+   internal void OpenHyperlinkPopup()
+   {
+      if (IsReadOnly) return;
+
+      // Pre-fill fields
+      EditableHyperlink? existing = FlowDoc.GetHyperlinkAtSelection();
+      bool isEdit = existing != null;
+
+      HyperlinkTextBox.Text = isEdit
+         ? existing!.Text ?? ""
+         : FlowDoc.Selection.GetText();
+
+      HyperlinkUrlBox.Text = existing?.NavigateUri ?? "";
+
+      // Update popup title and button visibility
+      HyperlinkPopupTitle.Text = isEdit ? "Edit Hyperlink" : "Insert Hyperlink";
+      HyperlinkDeleteButton.IsVisible = isEdit;
+
+      // Show the popup
+      HyperlinkPopup.IsOpen = true;
+
+      // Focus URL field when editing an existing link (text is already known),
+      // otherwise focus the text field (or URL field if text is pre-filled from selection).
+      if (isEdit)
+         HyperlinkUrlBox.Focus();
+      else if (string.IsNullOrEmpty(HyperlinkTextBox.Text))
+         HyperlinkTextBox.Focus();
+      else
+         HyperlinkUrlBox.Focus();
+   }
+
+   // XAML event handlers (wired in XAML code-behind)
+
+   internal void HyperlinkPopup_KeyDown(object? sender, KeyEventArgs e)
+   {
+      if (e.Key == Key.Escape)
+      {
+         CloseHyperlinkPopup();
+         e.Handled = true;
+      }
+      else if (e.Key == Key.Enter)
+      {
+         ConfirmHyperlink();
+         e.Handled = true;
+      }
+   }
+
+   internal void HyperlinkOkButton_Click(object? sender, RoutedEventArgs e)
+   {
+      ConfirmHyperlink();
+   }
+
+   internal void HyperlinkDeleteButton_Click(object? sender, RoutedEventArgs e)
+   {
+      CloseHyperlinkPopup();
+      FlowDoc.RemoveHyperlink();
+      this.Focus();
+   }
+
+   internal void HyperlinkCancelButton_Click(object? sender, RoutedEventArgs e)
+   {
+      CloseHyperlinkPopup();
+      this.Focus();
+   }
+
+   // Context menu handlers
+
+   internal void InsertHyperlinkMenuItem_Click(object? sender, RoutedEventArgs e)
+   {
+      OpenHyperlinkPopup();
+   }
+
+   internal void EditHyperlinkMenuItem_Click(object? sender, RoutedEventArgs e)
+   {
+      OpenHyperlinkPopup();
+   }
+
+   internal void RemoveHyperlinkMenuItem_Click(object? sender, RoutedEventArgs e)
+   {
+      FlowDoc.RemoveHyperlink();
+      this.Focus();
+   }
+
+   //  Private helpers 
+
+   private void ConfirmHyperlink()
+   {
+      string text = HyperlinkTextBox.Text?.Trim() ?? "";
+      string url = HyperlinkUrlBox.Text?.Trim() ?? "";
+
+      CloseHyperlinkPopup();
+
+      if (string.IsNullOrEmpty(url)) 
+      {
+         this.Focus();
+         return;
+      }
+
+      // Use the URL as display text if text field was left empty
+      if (string.IsNullOrEmpty(text))
+         text = url;
+
+      FlowDoc.InsertOrUpdateHyperlink(text, url);
+      this.Focus();
+   }
+
+   private void CloseHyperlinkPopup()
+   {
+      HyperlinkPopup.IsOpen = false;
+   }
+}

--- a/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_KeyDown.cs
@@ -50,6 +50,10 @@ public partial class RichTextBox
                   FlowDoc.SelectAll();
                   break;
 
+               case Key.K:
+                  OpenHyperlinkPopup();
+                  break;
+
                case Key.Delete:
                   if (IsReadOnly) return;
                   FlowDoc.DeleteWord(false);
@@ -103,7 +107,9 @@ public partial class RichTextBox
          switch (e.Key)
          {
             case Key.Escape:
-               if (PreeditOverlay.IsVisible)
+               if (HyperlinkPopupOpen)
+                  CloseHyperlinkPopup();
+               else if (PreeditOverlay.IsVisible)
                   HideIMEOverlay();
                break;
 

--- a/AvRichTextBox/Undo/Undos.cs
+++ b/AvRichTextBox/Undo/Undos.cs
@@ -409,6 +409,59 @@ internal class InsertLineBreakUndo(int insertParId, int insertedLBId, List<int> 
    }
 }
 
+/// <summary>
+/// Undo for hyperlink insert, update (text/URL), and remove operations.
+/// Restores the full set of affected paragraph(s) from clones taken before the edit.
+/// </summary>
+internal class HyperlinkParagraphUndo : IUndo
+{
+   // Convenience constructor for single-paragraph operations (update / remove)
+   internal HyperlinkParagraphUndo(Paragraph parClone, int parIndex, FlowDocument flowDoc, int origSelectionStart, int undoEditOffset)
+      : this([parClone], parIndex, flowDoc, origSelectionStart, undoEditOffset, false) { }
+
+   private readonly List<Paragraph> parClones;
+   private readonly int parIndex;
+   private readonly FlowDocument flowDoc;
+   private readonly int origSelectionStart;
+   private readonly bool firstParWasDeleted;
+
+   public int UndoEditOffset { get; }
+   public bool UpdateTextRanges => true;
+
+   internal HyperlinkParagraphUndo(List<Paragraph> parClones, int parIndex, FlowDocument flowDoc, int origSelectionStart, int undoEditOffset, bool firstParWasDeleted = false)
+   {
+      this.parClones           = parClones;
+      this.parIndex            = parIndex;
+      this.flowDoc             = flowDoc;
+      this.origSelectionStart  = origSelectionStart;
+      this.firstParWasDeleted  = firstParWasDeleted;
+      UndoEditOffset           = undoEditOffset;
+   }
+
+   public void PerformUndo()
+   {
+      try
+      {
+         flowDoc.disableRunTextUndo = true;
+
+         int lengthBefore = flowDoc.Text.Length;
+         flowDoc.RestoreDeletedBlocks(parClones, parIndex, firstParWasDeleted);
+         flowDoc.disableRunTextUndo = false;
+         int lengthAfter = flowDoc.Text.Length;
+
+         Dispatcher.UIThread.Post(() =>
+         {
+            flowDoc.Selection.Start = origSelectionStart;
+            flowDoc.Selection.End   = origSelectionStart;
+            flowDoc.UpdateSelection();
+            flowDoc.UpdateTextRanges(parClones[0].StartInDoc, lengthAfter - lengthBefore);
+         });
+      }
+      catch { Debug.WriteLine("Failed HyperlinkParagraphUndo at parIndex: " + parIndex); }
+   }
+}
+
+
 internal class DeleteLineBreakUndo(int parId, ((Type t1, int id1), (Type t2, int id2)) types, int lineBreakIdx, FlowDocument flowDoc, int origSelectionStart) : IUndo
 {
    public int UndoEditOffset => -1;

--- a/AvRichTextBox/Undo/Undos.cs
+++ b/AvRichTextBox/Undo/Undos.cs
@@ -426,7 +426,9 @@ internal class HyperlinkParagraphUndo : IUndo
    private readonly bool firstParWasDeleted;
 
    public int UndoEditOffset { get; }
-   public bool UpdateTextRanges => true;
+   // UpdateTextRanges is handled inside PerformUndo via Dispatcher.UIThread.Post;
+   // returning false prevents Undo() from issuing a second, conflicting UpdateTextRanges call.
+   public bool UpdateTextRanges => false;
 
    internal HyperlinkParagraphUndo(List<Paragraph> parClones, int parIndex, FlowDocument flowDoc, int origSelectionStart, int undoEditOffset, bool firstParWasDeleted = false)
    {

--- a/DemoApp_AvRichtextBox/App.axaml
+++ b/DemoApp_AvRichtextBox/App.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="DemoApp_AvRichtextBox.App"
              xmlns:local="using:DemoApp_AvRichtextBox"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
 	


### PR DESCRIPTION
Adds a popup to add/edit hyperlinks. The popup can be opened using the context menu or CTRL+K. Hyperlinks can also be removed using the context menu.
Please keep in mind that this is largely AI generated. I looked at the code and tested it, but sometimes I wasn't sure if it makes sense (for example the undo code).

The change RequestedThemeVariant="Light" slipped in one of the commits, because I use Windows 11 with Dark Theme and always have to set it to Light, because otherwise I don't see the text (font color is white). This is something I wanted do address after the hyperlink changes.