### PR TITLE
Fix RTF character escaping for non-ASCII text

### DIFF
--- a/AvRichTextBox/FlowDocument/FlowDocument_LoadSave.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_LoadSave.cs
@@ -25,6 +25,7 @@ public partial class FlowDocument
 			rtfContent = rtfContent.Replace("\\o \"}", "\\o \"\"}").Replace(" \"}", " }");
 			rtfContent = RemoveOverstrikeRegex().Replace(rtfContent, "\\o\"\"");
 		}
+		rtfContent = NormalizeCharacterEscapes(rtfContent);
 		using MemoryStream rtfStream = new(Encoding.UTF8.GetBytes(rtfContent));
 		using StreamReader streamReader = new(rtfStream);
 
@@ -70,6 +71,32 @@ public partial class FlowDocument
 	{
 		return GetRtfFromFlowDocument(this);
 	}
+
+	private static string NormalizeCharacterEscapes(string rtfContent)
+	{
+		rtfContent = AnsiHexEscapeRegex().Replace(rtfContent, match =>
+		{
+			byte ansiByte = Convert.ToByte(match.Groups[1].Value, 16);
+			return GetGroupedUnicodeEscape(HelperMethods.GetWindows1252Char(ansiByte));
+		});
+
+		return UnicodeEscapeRegex().Replace(rtfContent, match =>
+		{
+			int unicodeValue = int.Parse(match.Groups[1].Value);
+			return @"{\u" + unicodeValue + "?}";
+		});
+	}
+
+	private static string GetGroupedUnicodeEscape(char c)
+	{
+		return @"{\u" + (int)c + "?}";
+	}
+
+	[GeneratedRegex(@"(?<!\{)\\u(-?\d+)(.)")]
+	private static partial Regex UnicodeEscapeRegex();
+
+	[GeneratedRegex(@"\\'([0-9a-fA-F]{2})")]
+	private static partial Regex AnsiHexEscapeRegex();
 
 
 	internal void SaveXamlToFile(string fileName)

--- a/AvRichTextBox/SaveAndLoadFormats/RtfConversions/ContentToRtf.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/RtfConversions/ContentToRtf.cs
@@ -546,8 +546,8 @@ internal static partial class RtfConversions
                 sb.Append(@"\" + c); // RTF control characters
             else if (c == '"')
                 sb.Append(@"\'22"); // Escape double quote
-            else if (c > 127) // Non-ASCII (double-byte characters)
-                sb.Append(@"\u" + (int)c + "?"); // Unicode escape
+            else if (c > 127) // Non-ASCII
+                sb.Append(@"{\u" + (int)c + "?}"); // Grouped Unicode escape
             else
                 sb.Append(c);
 

--- a/AvRichTextBox/SaveAndLoadFormats/WordImportExport/HelperMethods.cs
+++ b/AvRichTextBox/SaveAndLoadFormats/WordImportExport/HelperMethods.cs
@@ -20,6 +20,42 @@ internal static partial class HelperMethods
    internal static double TwipToDip(double twips) => twips * (96.0 / 1440.0);
    internal static double DipToTwip(double dips) => dips * (1440.0 / 96.0);
 
+   internal static char GetWindows1252Char(byte ansiByte)
+   {
+      switch (ansiByte)
+      {
+         case 0x80: return '\u20ac';
+         case 0x82: return '\u201a';
+         case 0x83: return '\u0192';
+         case 0x84: return '\u201e';
+         case 0x85: return '\u2026';
+         case 0x86: return '\u2020';
+         case 0x87: return '\u2021';
+         case 0x88: return '\u02c6';
+         case 0x89: return '\u2030';
+         case 0x8a: return '\u0160';
+         case 0x8b: return '\u2039';
+         case 0x8c: return '\u0152';
+         case 0x8e: return '\u017d';
+         case 0x91: return '\u2018';
+         case 0x92: return '\u2019';
+         case 0x93: return '\u201c';
+         case 0x94: return '\u201d';
+         case 0x95: return '\u2022';
+         case 0x96: return '\u2013';
+         case 0x97: return '\u2014';
+         case 0x98: return '\u02dc';
+         case 0x99: return '\u2122';
+         case 0x9a: return '\u0161';
+         case 0x9b: return '\u203a';
+         case 0x9c: return '\u0153';
+         case 0x9e: return '\u017e';
+         case 0x9f: return '\u0178';
+      }
+
+      return (char)ansiByte;
+   }
+
    internal static void ResizeAndSaveBitmap(Bitmap originalBitmap, int newWidth, int newHeight, Stream memoryStream)
    {
       var renderTarget = new RenderTargetBitmap(new PixelSize(newWidth, newHeight));


### PR DESCRIPTION
## Summary
- Write non-ASCII RTF text as grouped Unicode escapes.
- Normalize incoming ANSI and Unicode escapes before parsing RTF content.
- Add Windows-1252 character mapping for ANSI escape conversion.