### PR TITLE
Fix table editing interactions

### DIFF
--- a/AvRichTextBox/Blocks/Block.cs
+++ b/AvRichTextBox/Blocks/Block.cs
@@ -140,7 +140,7 @@ public class Block : INotifyPropertyChanged
                 field = value;
                 NotifyPropertyChanged(nameof(SelectionStartInBlock));
                 if (this.IsTableCellBlock)
-                    this.OwningCell.Selected = SelectionStartInBlock == 0 && SelectionEndInBlock == BlockLength;  
+                    this.OwningCell.Selected = BlockLength > 0 && SelectionStartInBlock == 0 && SelectionEndInBlock == BlockLength;  
 
             }
         }
@@ -156,7 +156,7 @@ public class Block : INotifyPropertyChanged
                 field = value;
                 NotifyPropertyChanged(nameof(SelectionEndInBlock));
                 if (this.IsTableCellBlock)
-                    this.OwningCell.Selected = SelectionStartInBlock == 0 && SelectionEndInBlock == BlockLength;  
+                    this.OwningCell.Selected = BlockLength > 0 && SelectionStartInBlock == 0 && SelectionEndInBlock == BlockLength;  
             }
         }
     }

--- a/AvRichTextBox/EditableBlocks/EditableTable/EditableTable.cs
+++ b/AvRichTextBox/EditableBlocks/EditableTable/EditableTable.cs
@@ -12,6 +12,9 @@ public partial class EditableTable : ItemsControl
    private const double MinColumnWidth = 24;
    private const double MinRowHeight = 24;
 
+   private readonly Cursor _ewResizeCursor = new(StandardCursorType.SizeWestEast);
+   private readonly Cursor _nsResizeCursor = new(StandardCursorType.SizeNorthSouth);
+
    private Point _resizeStartPoint;
    private ResizeMode _resizeMode;
    private int _resizeIndex = -1;
@@ -48,8 +51,8 @@ public partial class EditableTable : ItemsControl
       ResizeHit hit = GetResizeHit(table, position);
       Cursor = hit.Mode switch
       {
-         ResizeMode.Column => new Cursor(StandardCursorType.SizeWestEast),
-         ResizeMode.Row => new Cursor(StandardCursorType.SizeNorthSouth),
+         ResizeMode.Column => _ewResizeCursor,
+         ResizeMode.Row => _nsResizeCursor,
          _ => null
       };
    }

--- a/AvRichTextBox/EditableBlocks/EditableTable/EditableTable.cs
+++ b/AvRichTextBox/EditableBlocks/EditableTable/EditableTable.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using System.Collections.ObjectModel;
 
@@ -6,6 +8,16 @@ namespace AvRichTextBox;
 
 public partial class EditableTable : ItemsControl
 {
+   private const double ResizeGripSize = 5;
+   private const double MinColumnWidth = 24;
+   private const double MinRowHeight = 24;
+
+   private Point _resizeStartPoint;
+   private ResizeMode _resizeMode;
+   private int _resizeIndex = -1;
+   private double _resizeStartPrimarySize;
+   private double _resizeStartSecondarySize;
+
    public bool IsEditable { get; set; } = true;
 
    public EditableTable()
@@ -18,6 +30,121 @@ public partial class EditableTable : ItemsControl
       this.UpdateLayout();
    }
 
+   protected override void OnPointerMoved(PointerEventArgs e)
+   {
+      base.OnPointerMoved(e);
+
+      if (DataContext is not Table table)
+         return;
+
+      Point position = e.GetPosition(this);
+      if (_resizeMode != ResizeMode.None)
+      {
+         ResizeTable(table, position);
+         e.Handled = true;
+         return;
+      }
+
+      ResizeHit hit = GetResizeHit(table, position);
+      Cursor = hit.Mode switch
+      {
+         ResizeMode.Column => new Cursor(StandardCursorType.SizeWestEast),
+         ResizeMode.Row => new Cursor(StandardCursorType.SizeNorthSouth),
+         _ => null
+      };
+   }
+
+   protected override void OnPointerPressed(PointerPressedEventArgs e)
+   {
+      base.OnPointerPressed(e);
+
+      if (!IsEditable || DataContext is not Table table)
+         return;
+
+      Point position = e.GetPosition(this);
+      ResizeHit hit = GetResizeHit(table, position);
+      if (hit.Mode == ResizeMode.None)
+         return;
+
+      _resizeMode = hit.Mode;
+      _resizeIndex = hit.Index;
+      _resizeStartPoint = position;
+      if (_resizeMode == ResizeMode.Column)
+      {
+         _resizeStartPrimarySize = table.ColDefs[_resizeIndex].Width.Value;
+         _resizeStartSecondarySize = table.ColDefs[_resizeIndex + 1].Width.Value;
+      }
+      else
+      {
+         _resizeStartPrimarySize = table.RowDefs[_resizeIndex].Height.Value;
+         _resizeStartSecondarySize = table.RowDefs[_resizeIndex + 1].Height.Value;
+      }
+
+      e.Pointer.Capture(this);
+      e.Handled = true;
+   }
+
+   protected override void OnPointerReleased(PointerReleasedEventArgs e)
+   {
+      base.OnPointerReleased(e);
+
+      if (_resizeMode == ResizeMode.None)
+         return;
+
+      _resizeMode = ResizeMode.None;
+      _resizeIndex = -1;
+      e.Pointer.Capture(null);
+      e.Handled = true;
+   }
+
+   private void ResizeTable(Table table, Point position)
+   {
+      if (_resizeMode == ResizeMode.Column)
+      {
+         double delta = position.X - _resizeStartPoint.X;
+         double primaryWidth = Math.Max(MinColumnWidth, _resizeStartPrimarySize + delta);
+         double secondaryWidth = Math.Max(MinColumnWidth, _resizeStartSecondarySize - (primaryWidth - _resizeStartPrimarySize));
+         primaryWidth = _resizeStartPrimarySize + (_resizeStartSecondarySize - secondaryWidth);
+
+         table.ColDefs[_resizeIndex].Width = new GridLength(primaryWidth, GridUnitType.Pixel);
+         table.ColDefs[_resizeIndex + 1].Width = new GridLength(secondaryWidth, GridUnitType.Pixel);
+      }
+      else if (_resizeMode == ResizeMode.Row)
+      {
+         double delta = position.Y - _resizeStartPoint.Y;
+         double primaryHeight = Math.Max(MinRowHeight, _resizeStartPrimarySize + delta);
+         double secondaryHeight = Math.Max(MinRowHeight, _resizeStartSecondarySize - (primaryHeight - _resizeStartPrimarySize));
+         primaryHeight = _resizeStartPrimarySize + (_resizeStartSecondarySize - secondaryHeight);
+
+         table.RowDefs[_resizeIndex].Height = new GridLength(primaryHeight, GridUnitType.Pixel);
+         table.RowDefs[_resizeIndex + 1].Height = new GridLength(secondaryHeight, GridUnitType.Pixel);
+      }
+
+      InvalidateMeasure();
+      UpdateLayout();
+   }
+
+   private static ResizeHit GetResizeHit(Table table, Point position)
+   {
+      double x = 0;
+      for (int index = 0; index < table.ColDefs.Count - 1; index++)
+      {
+         x += table.ColDefs[index].Width.Value;
+         if (Math.Abs(position.X - x) <= ResizeGripSize)
+            return new ResizeHit(ResizeMode.Column, index);
+      }
+
+      double y = 0;
+      for (int index = 0; index < table.RowDefs.Count - 1; index++)
+      {
+         y += table.RowDefs[index].Height.Value;
+         if (Math.Abs(position.Y - y) <= ResizeGripSize)
+            return new ResizeHit(ResizeMode.Row, index);
+      }
+
+      return new ResizeHit(ResizeMode.None, -1);
+   }
+
    public static readonly StyledProperty<ObservableCollection<EditableCell>> CellsProperty = AvaloniaProperty.Register<EditableTable, ObservableCollection<EditableCell>>(nameof(Cells), defaultValue: []);
    public ObservableCollection<EditableCell> Cells { get => GetValue(CellsProperty); set => SetValue(CellsProperty, value); }
 
@@ -28,6 +155,15 @@ public partial class EditableTable : ItemsControl
   
    ////public string GetText => string.Join("", ((Table)this.DataContext).Inlines.ToList().ConvertAll(edinline => edinline.InlineText));
 
+}
+
+internal readonly record struct ResizeHit(ResizeMode Mode, int Index);
+
+internal enum ResizeMode
+{
+   None,
+   Column,
+   Row
 }
 
 

--- a/AvRichTextBox/RichTextBox/RichTextBox_SelectionChanged.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_SelectionChanged.cs
@@ -86,7 +86,7 @@ public partial class RichTextBox : UserControl
          {
             //visible selection for table cells
             if (p.IsTableCellBlock)
-               p.OwningCell.Selected = (p.SelectionStartInBlock == 0 && p.SelectionEndInBlock >= p.BlockLength);
+               p.OwningCell.Selected = FlowDoc.Selection.Length > 0 && p.SelectionStartInBlock == 0 && p.SelectionEndInBlock >= p.BlockLength;
 
             if (parIsEmpty)
             {


### PR DESCRIPTION
## Summary
- Add mouse resizing for adjacent table rows and columns.
- Keep row and column resizing bounded by a minimum size.
- Avoid marking empty table-cell blocks as selected whole cells.