### PR TITLE
Fix caret visibility

### DIFF
--- a/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox.axaml.cs
@@ -212,7 +212,12 @@ public partial class RichTextBox : UserControl
    }
 
 
-   public void InvalidateCaret() { RtbVm.CaretVisible = true; }
+   public void InvalidateCaret()
+   {
+      UpdateSelectionIndicators();
+      RtbVm.CaretVisible = FlowDoc.Selection.Length == 0;
+      UpdateCaretVisibility();
+   }
    public void NewDocument() => FlowDoc.NewDocument();
    public void CreateNewDocument() { FlowDoc.NewDocument(); RtbVm.RTBScrollOffset = new Vector(0, 0); }
    //Load/save
@@ -314,8 +319,8 @@ public partial class RichTextBox : UserControl
          IterationCount = IterationCount.Infinite,
          Children =
             {
-                new KeyFrame { Cue = new (0.0), Setters = { new Setter(Rectangle.OpacityProperty, 0.0) } },
-                new KeyFrame { Cue = new (0.5), Setters = { new Setter(Rectangle.OpacityProperty, 1.0) } },
+                new KeyFrame { Cue = new (0.0), Setters = { new Setter(Rectangle.OpacityProperty, 1.0) } },
+                new KeyFrame { Cue = new (0.75), Setters = { new Setter(Rectangle.OpacityProperty, 1.0) } },
                 new KeyFrame { Cue = new (1.0), Setters = { new Setter(Rectangle.OpacityProperty, 0.0) } }
             }
       };

--- a/AvRichTextBox/RichTextBox/RichTextBox_PreEditOverlay.cs
+++ b/AvRichTextBox/RichTextBox/RichTextBox_PreEditOverlay.cs
@@ -77,10 +77,11 @@ public partial class RichTextBox
 
    private readonly Rectangle _CaretRect = new()
    {
-      StrokeThickness = 2,
+      Fill = Brushes.Black,
+      StrokeThickness = 0,
       Stroke = Brushes.Black,
       Height = 20,
-      Width = 1.5,
+      Width = 2,
       IsVisible = false,
       HorizontalAlignment = HorizontalAlignment.Left,
       VerticalAlignment = VerticalAlignment.Top,
@@ -127,14 +128,17 @@ public partial class RichTextBox
    {
       if (CaretBrush != null)
       {
+         _CaretRect.Fill = CaretBrush;
          _CaretRect.Stroke = CaretBrush;
       }
       else if (this.TryFindResource("TextControlForeground", this.ActualThemeVariant, out var resource) && resource is IBrush brush)
       {
+         _CaretRect.Fill = brush;
          _CaretRect.Stroke = brush;
       }
       else
       {
+         _CaretRect.Fill = Brushes.Black;
          _CaretRect.Stroke = Brushes.Black;
       }
    }


### PR DESCRIPTION
## Summary
- Update selection indicators when the caret is invalidated.
- Hide the caret while text is selected instead of forcing it visible.
- Draw the caret as a filled rectangle so it is easier to see.