### PR TITLE
Fix range inline edge selection

### DIFF
--- a/AvRichTextBox/FlowDocument/FlowDocument_Formatting.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Formatting.cs
@@ -197,17 +197,12 @@ public partial class FlowDocument
    {
       if (fontweight is not FontWeight applyFontWeight) return;
 
-      // Zero-length edge runs produced by range splitting must not affect the toggle decision
-      List<EditableRun> relevantRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.InlineLength > 0)];
-      if (relevantRuns.Count == 0)
-         relevantRuns = [.. ieds.OfType<EditableRun>()];
-
       // if all of the runs are bold, force style to Normal
       if (fontweight is FontWeight.Bold)
-         applyFontWeight = relevantRuns.All(edrun => edrun.FontWeight == FontWeight.Bold) ? FontWeight.Normal : FontWeight.Bold;
+         applyFontWeight = ieds.All(ar => ar is EditableRun edrun && edrun.FontWeight == FontWeight.Bold) ? FontWeight.Normal : FontWeight.Bold;
       // if all of the runs are normal, force style to Bold
       else if (fontweight is FontWeight.Normal)
-         applyFontWeight = relevantRuns.All(edrun => edrun.FontWeight == FontWeight.Normal) ? FontWeight.Bold : FontWeight.Normal;
+         applyFontWeight = ieds.All(ar => ar is EditableRun edrun && edrun.FontWeight == FontWeight.Normal) ? FontWeight.Bold : FontWeight.Normal;
 
 
       foreach (EditableRun erun in ieds.OfType<EditableRun>())
@@ -219,17 +214,12 @@ public partial class FlowDocument
    {
       if (fontstyle is not FontStyle applyFontStyle) return;
 
-      // Zero-length edge runs produced by range splitting must not affect the toggle decision
-      List<EditableRun> relevantRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.InlineLength > 0)];
-      if (relevantRuns.Count == 0)
-         relevantRuns = [.. ieds.OfType<EditableRun>()];
-
       // if all of the runs are italic, force style to Normal
       if (fontstyle is FontStyle.Italic)
-         applyFontStyle = relevantRuns.All(edrun => edrun.FontStyle == FontStyle.Italic) ? FontStyle.Normal : FontStyle.Italic;
+         applyFontStyle = ieds.All(ar => ar is EditableRun edrun && edrun.FontStyle == FontStyle.Italic) ? FontStyle.Normal : FontStyle.Italic;
       // if all of the runs are normal, force style to Italic
       else if (fontstyle is FontStyle.Normal)
-         applyFontStyle = relevantRuns.All(edrun => edrun.FontStyle == FontStyle.Normal) ? FontStyle.Italic : FontStyle.Normal;
+         applyFontStyle = ieds.All(ar => ar is EditableRun edrun && edrun.FontStyle == FontStyle.Normal) ? FontStyle.Italic : FontStyle.Normal;
       // otherwise (if mixed), apply italic to all runs
       foreach (EditableRun erun in ieds.OfType<EditableRun>())
             erun.FontStyle = applyFontStyle; 
@@ -241,19 +231,17 @@ public partial class FlowDocument
    {
       if (textDecLocation is not TextDecorationLocation applyTextDecLoc) return;
 
-      // Zero-length edge runs produced by range splitting must not affect the toggle decision
-      List<EditableRun> relevantRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.InlineLength > 0)];
-      if (relevantRuns.Count == 0)
-         relevantRuns = [.. ieds.OfType<EditableRun>()];
-
-      // Get all runs already carrying this text dec
-      List<EditableRun> applyToRuns = [.. relevantRuns.Where(edrun => edrun.TextDecorations != null && edrun.TextDecorations.Any(tdec => tdec.Location == applyTextDecLoc))];
-      if (applyToRuns.Count == relevantRuns.Count)
+      // Get all runs without this new text dec
+      List<EditableRun> applyToRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.TextDecorations != null && edrun.TextDecorations.Any(tdec => tdec.Location == applyTextDecLoc))];
+      if (applyToRuns.Count == ieds.Count)
       { // all runs contain textdec, so remove from all 
-         foreach (EditableRun erun in applyToRuns)
+         foreach (EditableRun erun in ieds.OfType<EditableRun>())
          {
-            TextDecorationCollection newDec = [.. erun.TextDecorations!.Where(cdec => cdec.Location != applyTextDecLoc)];
-            erun.TextDecorations = newDec.Count == 0 ? null : newDec;
+            if (erun.TextDecorations is TextDecorationCollection currentDec)
+            {
+               currentDec.RemoveAll(currentDec.Where(cdec => cdec.Location == applyTextDecLoc));
+               if (currentDec.Count == 0) currentDec = null!;
+            }
          }
       }
       else

--- a/AvRichTextBox/FlowDocument/FlowDocument_Formatting.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_Formatting.cs
@@ -197,12 +197,17 @@ public partial class FlowDocument
    {
       if (fontweight is not FontWeight applyFontWeight) return;
 
+      // Zero-length edge runs produced by range splitting must not affect the toggle decision
+      List<EditableRun> relevantRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.InlineLength > 0)];
+      if (relevantRuns.Count == 0)
+         relevantRuns = [.. ieds.OfType<EditableRun>()];
+
       // if all of the runs are bold, force style to Normal
       if (fontweight is FontWeight.Bold)
-         applyFontWeight = ieds.All(ar => ar is EditableRun edrun && edrun.FontWeight == FontWeight.Bold) ? FontWeight.Normal : FontWeight.Bold;
+         applyFontWeight = relevantRuns.All(edrun => edrun.FontWeight == FontWeight.Bold) ? FontWeight.Normal : FontWeight.Bold;
       // if all of the runs are normal, force style to Bold
       else if (fontweight is FontWeight.Normal)
-         applyFontWeight = ieds.All(ar => ar is EditableRun edrun && edrun.FontWeight == FontWeight.Normal) ? FontWeight.Bold : FontWeight.Normal;
+         applyFontWeight = relevantRuns.All(edrun => edrun.FontWeight == FontWeight.Normal) ? FontWeight.Bold : FontWeight.Normal;
 
 
       foreach (EditableRun erun in ieds.OfType<EditableRun>())
@@ -214,12 +219,17 @@ public partial class FlowDocument
    {
       if (fontstyle is not FontStyle applyFontStyle) return;
 
+      // Zero-length edge runs produced by range splitting must not affect the toggle decision
+      List<EditableRun> relevantRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.InlineLength > 0)];
+      if (relevantRuns.Count == 0)
+         relevantRuns = [.. ieds.OfType<EditableRun>()];
+
       // if all of the runs are italic, force style to Normal
       if (fontstyle is FontStyle.Italic)
-         applyFontStyle = ieds.All(ar => ar is EditableRun edrun && edrun.FontStyle == FontStyle.Italic) ? FontStyle.Normal : FontStyle.Italic;
+         applyFontStyle = relevantRuns.All(edrun => edrun.FontStyle == FontStyle.Italic) ? FontStyle.Normal : FontStyle.Italic;
       // if all of the runs are normal, force style to Italic
       else if (fontstyle is FontStyle.Normal)
-         applyFontStyle = ieds.All(ar => ar is EditableRun edrun && edrun.FontStyle == FontStyle.Normal) ? FontStyle.Italic : FontStyle.Normal;
+         applyFontStyle = relevantRuns.All(edrun => edrun.FontStyle == FontStyle.Normal) ? FontStyle.Italic : FontStyle.Normal;
       // otherwise (if mixed), apply italic to all runs
       foreach (EditableRun erun in ieds.OfType<EditableRun>())
             erun.FontStyle = applyFontStyle; 
@@ -231,17 +241,19 @@ public partial class FlowDocument
    {
       if (textDecLocation is not TextDecorationLocation applyTextDecLoc) return;
 
-      // Get all runs without this new text dec
-      List<EditableRun> applyToRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.TextDecorations != null && edrun.TextDecorations.Any(tdec => tdec.Location == applyTextDecLoc))];
-      if (applyToRuns.Count == ieds.Count)
+      // Zero-length edge runs produced by range splitting must not affect the toggle decision
+      List<EditableRun> relevantRuns = [.. ieds.OfType<EditableRun>().Where(edrun => edrun.InlineLength > 0)];
+      if (relevantRuns.Count == 0)
+         relevantRuns = [.. ieds.OfType<EditableRun>()];
+
+      // Get all runs already carrying this text dec
+      List<EditableRun> applyToRuns = [.. relevantRuns.Where(edrun => edrun.TextDecorations != null && edrun.TextDecorations.Any(tdec => tdec.Location == applyTextDecLoc))];
+      if (applyToRuns.Count == relevantRuns.Count)
       { // all runs contain textdec, so remove from all 
-         foreach (EditableRun erun in ieds.OfType<EditableRun>())
+         foreach (EditableRun erun in applyToRuns)
          {
-            if (erun.TextDecorations is TextDecorationCollection currentDec)
-            {
-               currentDec.RemoveAll(currentDec.Where(cdec => cdec.Location == applyTextDecLoc));
-               if (currentDec.Count == 0) currentDec = null!;
-            }
+            TextDecorationCollection newDec = [.. erun.TextDecorations!.Where(cdec => cdec.Location != applyTextDecLoc)];
+            erun.TextDecorations = newDec.Count == 0 ? null : newDec;
          }
       }
       else

--- a/AvRichTextBox/FlowDocument/FlowDocument_InlineManipulation.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_InlineManipulation.cs
@@ -1,5 +1,4 @@
-﻿using DocumentFormat.OpenXml.Drawing.Diagrams;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 
 namespace AvRichTextBox;
 
@@ -21,12 +20,10 @@ public partial class FlowDocument
       {
          int ilineAbsoluteStart = p.StartInDoc + iline.TextPositionOfInlineInParagraph;
          int ilineAbsoluteEnd = ilineAbsoluteStart + iline.InlineLength;
-         bool AtStart = ilineAbsoluteEnd > trange.Start;
-         bool withinRange = iline.IsLastInlineOfParagraph switch
-         {
-            true =>  AtStart && ilineAbsoluteStart <= trange.End,
-            false => AtStart && ilineAbsoluteStart < trange.End
-         };
+         //bool EndAtLeastStart = ilineAbsoluteEnd > trange.Start;
+         bool EndAtLeastStart = ilineAbsoluteEnd >= trange.Start;
+
+         bool withinRange = EndAtLeastStart && ilineAbsoluteStart < trange.End;
 
          return withinRange;
       }

--- a/AvRichTextBox/FlowDocument/FlowDocument_InlineManipulation.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument_InlineManipulation.cs
@@ -22,8 +22,13 @@ public partial class FlowDocument
          int ilineAbsoluteEnd = ilineAbsoluteStart + iline.InlineLength;
          //bool EndAtLeastStart = ilineAbsoluteEnd > trange.Start;
          bool EndAtLeastStart = ilineAbsoluteEnd >= trange.Start;
+         bool EndsAtInlineStart = ilineAbsoluteStart == trange.End;
 
-         bool withinRange = EndAtLeastStart && ilineAbsoluteStart < trange.End;
+         bool withinRange = (iline.IsLastInlineOfParagraph && iline is not EditableInlineUIContainer) switch
+         {
+            true => EndAtLeastStart && ilineAbsoluteStart <= trange.End && !EndsAtInlineStart,
+            false => EndAtLeastStart && ilineAbsoluteStart < trange.End
+         };
 
          return withinRange;
       }


### PR DESCRIPTION
## Summary
This PR no longer changes the formatting toggle logic directly.

The current net change is in `GetTextRangeInlines(...)`: it keeps the existing last-inline handling, but excludes the one edge case where an inline starts exactly at `trange.End`.

The effective code change is intentionally small:
- Add `EndsAtInlineStart = ilineAbsoluteStart == trange.End`.
- Add `!EndsAtInlineStart` to the existing last-inline branch.

This prevents formatting a selected range that ends at the start of the final inline from treating that inline as selected and creating a zero-length edge run.