### PR TITLE
Guard delayed document initialization against empty paragraph state

### DIFF
--- a/AvRichTextBox/FlowDocument/FlowDocument.cs
+++ b/AvRichTextBox/FlowDocument/FlowDocument.cs
@@ -233,7 +233,7 @@ public partial class FlowDocument : AvaloniaObject
 
         Dispatcher.UIThread.Post(() =>
         {
-            if (AllParagraphs.ToList()[0] is Paragraph firstPar)
+            if (AllParagraphs.FirstOrDefault() is Paragraph firstPar)
             {  //Required for initial caret display
                 firstPar.CallRequestTextBoxFocus();
                 firstPar.CallRequestTextLayoutInfoStart();


### PR DESCRIPTION
## Summary

- Query the current paragraph collection defensively when the delayed initialization callback runs.
- Skip focus and text-layout initialization when the document has been cleared or replaced before that callback executes.

## Root cause

`InitializeDocument()` posts work at `DispatcherPriority.Background`. The callback previously accessed the first paragraph with `[0]`, relying on state that was valid when the work was scheduled. A host can clear or replace `FlowDocument.Blocks` before the dispatcher executes the callback, leaving the paragraph collection empty and causing an `ArgumentOutOfRangeException` from the dispatcher.

## Fix

Use `FirstOrDefault()` inside the delayed callback and run the focus/layout initialization only when a paragraph still exists. If the document state has already been replaced, the obsolete initialization work becomes a no-op.

## Validation

- `dotnet build AvRichTextBox.sln` completed with 0 errors.
- Launched `DemoApp_AvRichTextBox`. Its loaded path clears and replaces `FlowDocument.Blocks` after control initialization; the application remained responsive and rendered the replacement paragraph and table.
